### PR TITLE
Fix CI tsc: global → globalThis

### DIFF
--- a/client/src/components/forms/InvoiceEditor.test.tsx
+++ b/client/src/components/forms/InvoiceEditor.test.tsx
@@ -61,7 +61,7 @@ const baseInvoice = (over: Partial<InvoiceData> = {}): InvoiceData => ({
 // Dispatch fetch by URL so the various component-internal fetches all
 // get sensible empty responses without one polluting the other.
 const installFetchMock = () => {
-  vi.spyOn(global, 'fetch').mockImplementation((url) => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((url: RequestInfo | URL) => {
     const u = typeof url === 'string' ? url : (url as Request).url;
     const empty = { status: 'success', data: { clients: [], inventory: [] } };
     return Promise.resolve({

--- a/client/src/components/lists/InvoicesGrid.test.tsx
+++ b/client/src/components/lists/InvoicesGrid.test.tsx
@@ -61,7 +61,7 @@ const makeInvoice = (over: Partial<InvoiceData> & { customer_id?: number }): Inv
 };
 
 const mockFetch = (invoices: InvoiceData[]) => {
-  return vi.spyOn(global, 'fetch').mockResolvedValue({
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
     ok: true,
     status: 200,
     json: () =>
@@ -241,7 +241,7 @@ describe('InvoicesGrid', () => {
   });
 
   it('shows an error banner when the fetch fails', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,
       status: 500,
       json: () => Promise.resolve({}),


### PR DESCRIPTION
## Summary

Hot-fix for the failed PR #6 deploy build. The merge of `2.0 → main` succeeded but the GHA deploy crashed during `docker build` at `tsc --noEmit && vite build` with:

```
src/components/forms/InvoiceEditor.test.tsx(64,12): TS2304: Cannot find name 'global'.
src/components/forms/InvoiceEditor.test.tsx(64,49): TS7006: Parameter 'url' implicitly has an 'any' type.
src/components/lists/InvoicesGrid.test.tsx(64,19): TS2304: Cannot find name 'global'.
src/components/lists/InvoicesGrid.test.tsx(244,14): TS2304: Cannot find name 'global'.
```

Three `vi.spyOn(global, 'fetch')` call sites use Node's `global` — fine locally under vitest (which aliases it), but `client/`'s tsconfig has no `@types/node` so tsc rejects it. Swap `global` → `globalThis`. Also adds an explicit `(url: RequestInfo | URL)` type on the InvoiceEditor mock callback to fix the related TS7006.

These errors pre-dated the 2.0 work — they were carried in the test files since 2026-05-18 and only surfaced now because PR #6's docker build was the first to actually run tsc against them.

## Test plan

- [x] `npx tsc --noEmit` in `client/` returns exit 0
- [x] `npm run build` in `client/` completes cleanly (`tsc --noEmit && vite build`)
- [x] `npm test` in `client/` — 52 tests pass
- [ ] GHA Deploy workflow on this PR completes both image builds + EC2 push

Once merged, monitor the deploy run; it should produce + ship the 2.0 image.