### PR TITLE
Hotfix: drop orphan hideNav crashing App on render

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -71,8 +71,6 @@ const App = () => {
 		)
 	);
 	const path = window.location.pathname;
-	const hideNav =
-		url.includes("form") || path === "/auth" || isPublicPath(path);
 	return (
 		<>
 			<Provider>


### PR DESCRIPTION
## Summary

Prod was blank after PR #7's deploy. Browser console threw:

\`\`\`
ReferenceError: url is not defined
\`\`\`

PR #6's back-merge of \`main → 2.0\` brought in a leftover from main's App.jsx:

\`\`\`js
const hideNav =
  url.includes(\"form\") || path === \"/auth\" || isPublicPath(path);
\`\`\`

Neither \`url\` nor \`isPublicPath\` exists in 2.0's App.jsx — both were local to main's version. The variable was never used downstream, so the resolution should have dropped it but didn't. App.jsx is \`.jsx\`, so tsc didn't catch it; vite built clean; the bundle threw on every render and React never mounted.

Deleted the dead variable. Navbar-hide logic in the JSX below uses explicit per-path checks already.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 52/52 passing
- [ ] GHA deploy completes
- [ ] \`https://airtightshippingcontainer.com/\` loads in incognito (no blank page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)