### PR TITLE
Hotfix: known_hosts hostname mismatch breaks deploy SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,10 +42,12 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           # Pin the host key from a secret instead of TOFU via
           # ssh-keyscan. Without this, a one-time MITM on the runner
-          # → EC2 path on any deploy can hand the attacker shell on
-          # the host. The secret should contain the literal known_hosts
-          # line, e.g. "ec2-1-2-3-4.compute.amazonaws.com ssh-ed25519 AAA...".
-          echo "${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
+          # → EC2 path on any deploy hands the attacker shell on the
+          # host. The secret holds only the key (e.g.
+          # "ssh-ed25519 AAA...") — the hostname is concatenated from
+          # EC2_HOST below so the entry always matches whatever
+          # hostname the next line connects to.
+          echo "${{ secrets.EC2_HOST }} ${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} \


### PR DESCRIPTION
## Summary

PR #9's deploy failed at the SSH step:

\`\`\`
No ED25519 host key is known for *** and you have requested strict checking.
Host key verification failed.
\`\`\`

Root cause: the version of \`deploy.yml\` that landed in PR #9 baked the hostname into the \`EC2_SSH_HOST_KEY\` secret value itself, but the secret was set with the wrong hostname prefix (mismatched what \`secrets.EC2_HOST\` resolves to at SSH time).

## Fix

Strip the hostname out of the secret entirely. Construct \`known_hosts\` from \`secrets.EC2_HOST + secrets.EC2_SSH_HOST_KEY\` at deploy time, so the entry always matches whatever hostname the ssh command connects to.

\`EC2_SSH_HOST_KEY\` has already been re-set to the bare key:
\`\`\`
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDZBQXhOKIi+2iDeKb2gA5fxT8TYlXtX1yBnY9L3IbiW
\`\`\`
(verified against EC2's \`/etc/ssh/ssh_host_ed25519_key.pub\`)

One commit, one file changed. Merge → deploy retries automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)