### PR TITLE
Fix: quote promote crashed on nonexistent quote_lines table

### DIFF
--- a/server/routes/v2/quote.js
+++ b/server/routes/v2/quote.js
@@ -366,7 +366,7 @@ router.post(
 			// asked us to enforce 1:1 so the promoted invoice always
 			// matches the quoted scope.
 			const { rows: lineRows } = await client.query(
-				"SELECT COUNT(*)::int AS n FROM quote_lines WHERE quote_id = $1",
+				"SELECT COUNT(*)::int AS n FROM quote_line_items WHERE quote_id = $1",
 				[quoteId],
 			);
 			const lineCount = lineRows[0].n;


### PR DESCRIPTION
## What

One-line fix. The 1:1 line→container gate in `POST /api/v2/quote/:id/promote` queried `quote_lines`, which does not exist — the table is `quote_line_items`.

```diff
-  "SELECT COUNT(*)::int AS n FROM quote_lines WHERE quote_id = $1",
+  "SELECT COUNT(*)::int AS n FROM quote_line_items WHERE quote_id = $1",
```

## Why

Every promote attempt 500'd with `relation "quote_lines" does not exist`. Confirmed in prod backend logs against quote **Q202606001** (JakeaBob's Bay / box FAMU 827164-0) — the operator hit it repeatedly this week. The rest of `quote.js` and `lib/quote-ops.ts` already use the correct table name; this was an isolated typo in the inline count check shipped in d5a71e4 (PR #13). The unit tests on `lib/quote-ops.ts` didn't catch it because the buggy query lives in the route handler, outside the tested helper.

## Testing

- `npm test` in `server/`: all 12 quote tests green; 225/226 overall. The 1 failure (`sh-checkout.test.ts:135`) is a pre-existing date-relative test bug (fixture seeds `now() - interval '5 days'` ≈ 2026-06-01 vs hardcoded `nextMonthStart='2026-06-01'`), unrelated to this change — tracked separately.
- `tsc --noEmit` clean.

## Follow-ups (separate bundled PR)

Quote email same-domain deliverability fix + Puppeteer singleton consolidation + container `mem_limit`, per the outage postmortem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)