### PR TITLE
Fix: consolidate Puppeteer to one browser + cap backend memory (outage remediation)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ services:
   backend:
     image: ghcr.io/harrylynchh/airtight-backend:latest
     restart: unless-stopped
+    # Cap the blast radius: a PDF/Chromium memory spike OOM-kills and
+    # restarts THIS container in isolation instead of dragging the whole
+    # 1 GB host into a hard lock (see docs/postmortem.md, 2026-06-04).
+    mem_limit: 600m
     ports:
       - "3001:3001"
     extra_hosts:

--- a/docs/postmortem.md
+++ b/docs/postmortem.md
@@ -1,0 +1,149 @@
+# Postmortem: Airtight service outage (EC2 hard-lock)
+
+**Date of incident:** 2026-06-04 (failure observed; box frozen from ~04:09 UTC)
+**Status:** Root cause confirmed. Mitigations identified, not yet applied.
+**Audience:** Claude Code agent — this document is context for implementing the fix.
+
+---
+
+## TL;DR
+
+The EC2 instance hard-locked because the **backend container's Puppeteer / headless Chromium usage exhausted memory** on a **1 GB instance with zero swap**. The box was under continuous, severe memory pressure for ~18 hours, then froze completely — which is why SSH hung. A manual reboot brought it back. The OOM killer had been firing (it killed a Chromium process), but with no swap the machine eventually thrashed into a total lockup rather than recovering.
+
+**The cure** is fixing the Puppeteer lifecycle in the backend code. **The seatbelts** are adding swap, capping container memory, and right-sizing the instance.
+
+---
+
+## Environment
+
+- **Instance:** ~954 MB RAM (1 GB class, e.g. t2/t3.micro), **0 swap**.
+- **Root disk:** 19 GB, 79% used (~4 GB free) — NOT a factor.
+- **OS:** Ubuntu 24.x, systemd, persistent journald.
+- **Working dir:** `~/airtight-container` (docker compose project).
+- **Services on the host:** PostgreSQL 16, nginx, Docker/containerd, two Node containers, amazon-ssm-agent, snapd.
+- **Containers:**
+  - `airtight-container-frontend-1` — `ghcr.io/harrylynchh/airtight-frontend:latest`, serves on `8080`. nginx-based static/frontend.
+  - `airtight-container-backend-1` — `ghcr.io/harrylynchh/airtight-backend:latest`, serves on `3001`. **This is the culprit.**
+
+### Backend dependencies (from package.json)
+```
+@aws-sdk/client-s3, @aws-sdk/client-textract, @aws-sdk/s3-request-presigner,
+better-auth, cors, dotenv, drizzle-orm, express, express-rate-limit, helmet,
+node-cron, pg, puppeteer (^24.43.1), react, react-dom, resend, tsx, twilio, zod
+```
+- `puppeteer` is installed; `/usr/bin/chromium` exists in the image.
+- `node-cron` is present → there may be a **scheduled job** invoking Puppeteer.
+- `@aws-sdk/client-textract` + `client-s3` → likely workflow is HTML→PDF or screenshot rendering, possibly uploaded to S3, possibly OCR'd.
+
+---
+
+## Timeline (UTC)
+
+- **Boot `-2`** (the long-lived production boot): ran Feb 24 → Jun 4 04:09:14.
+- **Jun 3, ~10:20** — Kernel OOM event. `Out of memory: Killed process 1147045 (chromium) total-vm:50794040kB, anon-rss:25448kB ... UID:100`. OOM dump confirms `Total swap = 0kB`.
+- **Jun 3 ~17:00 → Jun 4 04:09** — Unbroken wall of `systemd-journald: Under memory pressure, flushing caches`, accelerating toward the end. System chronically starved for ~18h.
+- Collateral failures during starvation: `snapd.service: Watchdog timeout`, repeated `snapd start operation timed out`, `DHCPv4 ... Connection timed out`, `apt-daily.service failed`. These are **symptoms**, not causes — a box too starved to schedule processes.
+- **Jun 4 04:09:14** — last log line of boot `-2`, mid-stream, **no shutdown sequence**. This is the freeze. SSH hangs here.
+- **Jun 4 04:13:25–04:13:43** — boot `-1`: an 18-second clean poweroff = the user-initiated reboot.
+- **Jun 4 04:14:37+** — boot `0`: current healthy boot. Containers came back up via restart policy (`Up 7 minutes`, `Created 5 days ago` → restarted, not recreated; pre-crash docker logs preserved).
+
+---
+
+## Evidence chain (how we know)
+
+1. **Disk ruled out:** `df -h` showed 79% used, persistent volume → if it had filled pre-reboot it would still be full. It wasn't.
+2. **Memory confirmed as the axis:** `free -m` showed 954 MB total, **0 swap**.
+3. **OOM confirmed:** `journalctl -b -2 -p warning` surfaced the kernel OOM dump killing `chromium`, with `Total swap = 0kB`.
+4. **Freeze confirmed:** boot `-2` ends mid-log with no shutdown lines; ~4-min gap to next boot = dead/frozen window matching the SSH hang.
+5. **Source confirmed:** `docker exec ... backend-1` showed `puppeteer` in `node_modules/.bin` and `/usr/bin/chromium` present. The OOM'd Chromium (host `UID:100`) maps to the container's service user.
+6. **Frontend ruled out:** frontend "chrome" log hits were just bot User-Agent strings, not a running browser.
+
+---
+
+## Root cause
+
+The backend uses **Puppeteer (headless Chromium)** for rendering (likely PDF/screenshot generation, possibly on a `node-cron` schedule). On a 1 GB box with no swap, Chromium's memory footprint (300–500 MB per active render) plus Postgres + nginx + Docker + two Node apps left no headroom. The most likely code-level bug is a **leaked browser and/or page** (launched but never `.close()`d) or **launching a browser per request/job** instead of reusing one. With no swap to absorb the spikes, the kernel OOM-killed Chromium repeatedly and ultimately the whole machine thrashed into a hard lock.
+
+`node-cron` + a per-run leak would produce the observed slow ~18h climb independent of user traffic — this is the leading hypothesis for the *pattern* and should be checked first.
+
+---
+
+## Fixes
+
+### 1. Code fix (the cure) — backend Puppeteer lifecycle
+
+Audit how Puppeteer is invoked. Starting point:
+```
+docker exec airtight-container-backend-1 sh -c 'grep -rn "puppeteer\|\.launch(\|\.newPage(\|\.close()" --include=*.ts --include=*.js src 2>/dev/null | head -40'
+```
+
+Verify and enforce:
+- Every `browser.launch()` has a matching `browser.close()` in a **`finally`** block (closes even on throw).
+- Every `browser.newPage()` has a matching `page.close()` (leaked pages are as fatal as leaked browsers).
+- **Do not launch a browser per request/job.** Reuse one long-lived browser instance, or if launching per-job, guarantee teardown.
+- If a `node-cron` job uses Puppeteer, confirm runs can't overlap (a slow run + next tick = two concurrent Chromiums).
+
+Robust pattern:
+```js
+let browser;
+try {
+  browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--single-process']
+  });
+  const page = await browser.newPage();
+  try {
+    // ... render / pdf ...
+  } finally {
+    await page.close();
+  }
+} finally {
+  if (browser) await browser.close();
+}
+```
+- `--disable-dev-shm-usage`: **critical in Docker** — Chromium defaults to `/dev/shm`, which is tiny in containers; without this it can balloon or crash.
+- `--single-process`: reduces footprint on a small box (slight stability tradeoff — test it).
+- `--no-sandbox`: typically required when running as root in a container.
+
+### 2. Swap (seatbelt — do immediately, prevents hard-lock)
+```
+sudo fallocate -l 2G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+free -m   # confirm Swap is nonzero
+```
+This alone would likely have kept the box reachable during the incident (degrade instead of freeze).
+
+### 3. Cap container memory (seatbelt — contain the blast radius)
+In the compose file:
+```yaml
+  backend:
+    mem_limit: 600m
+    restart: unless-stopped
+```
+A capped container gets OOM-killed and auto-restarted in isolation, instead of dragging down the host.
+
+### 4. Right-size the instance (seatbelt — remove the structural squeeze)
+Postgres + nginx + Docker + two Node containers + headless Chromium on 954 MB is under-provisioned even with perfect code.
+- **Floor:** t3.small (2 GB).
+- **Recommended if PDF/render is a core feature:** 4 GB.
+- Check current type: `curl http://169.254.169.254/latest/meta-data/instance-type` (or `ec2-metadata --instance-type`).
+
+### Suggested order of operations
+1. Add swap (5 min, immediate safety net).
+2. Read the Puppeteer code via the grep above; patch close/teardown and concurrency. **(Root-cause fix.)**
+3. Add the container memory cap.
+4. Plan/execute the instance bump.
+
+---
+
+## Secondary / unrelated findings (not the cause — backlog)
+
+- **Bot scanning:** A single IP (`20.116.59.164`) was probing the frontend for vulns (`/wp-admin/`, `/sql.php`, `/info.php`, `/.well-known/*.php`, etc.). Not running WordPress/PHP so the probes 200'd harmlessly, but worth hardening later (fail2ban, security-group tightening, or returning 404s). **Not related to the outage.**
+- **snapd churn / watchdog timeouts:** symptoms of the starvation, not a separate issue. Should clear once memory is healthy.
+
+---
+
+## Open questions for the fix
+
+1. Where exactly is Puppeteer invoked — per HTTP request, or via `node-cron`? (Determines whether the fix is teardown, reuse, or concurrency-throttling.)
+2. Is there a long-lived browser instance pattern already, or launch-per-call?
+3. What's the current EC2 instance type? (Confirms how tight the budget really is.)

--- a/server/lib/pdf.ts
+++ b/server/lib/pdf.ts
@@ -15,11 +15,9 @@
 // Docker image, this lands via a multi-stage build copying the artifact
 // from a client-build stage into the backend image.
 //
-// The browser instance is intentionally module-singleton: launching
-// Chromium is ~300-500ms, and we'd rather amortize that cost across
-// many PDFs in the same backend process than pay it per request.
+// The headless Chromium is shared across all PDF render paths via
+// lib/puppeteer.ts (see that file for the recycle/lifecycle rationale).
 
-import puppeteer, { type Browser } from 'puppeteer';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 import { readFile } from 'node:fs/promises';
@@ -27,6 +25,12 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import db from '../db/index.js';
 import { putObject, getObjectBytes } from './s3.js';
+import { withPage, closeBrowser } from './puppeteer.js';
+
+// Re-exported so existing scripts (smoke-pdf, rerender-all-invoices) that
+// import closeBrowser from this module keep working after the browser
+// moved into lib/puppeteer.ts.
+export { closeBrowser };
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,32 +48,9 @@ const BUNDLE_CSS = path.join(BUNDLE_DIR, 'InvoiceTemplate.css');
 
 // ---- shared lazy singletons -----------------------------------------
 
-let _browser: Browser | null = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _template: any = null;
 let _css: string | null = null;
-
-async function getBrowser(): Promise<Browser> {
-  if (_browser) return _browser;
-  _browser = await puppeteer.launch({
-    headless: true,
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-      '--disable-dev-shm-usage',
-    ],
-  });
-  return _browser;
-}
-
-// Exported so a graceful-shutdown handler can call it; production
-// doesn't reuse this on hot-reload paths.
-export async function closeBrowser(): Promise<void> {
-  if (_browser) {
-    await _browser.close();
-    _browser = null;
-  }
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getTemplate(): Promise<any> {
@@ -259,11 +240,8 @@ export async function renderInvoicePdf(invoiceId: number): Promise<Buffer> {
   log('render-to-string');
   const ssrHtml = renderToString(createElement(Template, { data }));
   const html = wrapHtml(ssrHtml, css);
-  log(`html=${html.length} bytes, launching browser`);
-  const browser = await getBrowser();
-  log('new page');
-  const page = await browser.newPage();
-  try {
+  log(`html=${html.length} bytes, acquiring page`);
+  return withPage(async (page) => {
     log('setContent');
     // setContent's waitUntil excludes networkidle in Puppeteer 24.
     // Wait on the FontFaceSet promise instead so the rendered PDF uses
@@ -279,10 +257,7 @@ export async function renderInvoicePdf(invoiceId: number): Promise<Buffer> {
     });
     log(`pdf=${pdf.length} bytes`);
     return Buffer.from(pdf);
-  } finally {
-    log('close page');
-    await page.close();
-  }
+  });
 }
 
 export function invoicePdfS3Key(invoiceId: number): string {

--- a/server/lib/puppeteer.ts
+++ b/server/lib/puppeteer.ts
@@ -1,0 +1,106 @@
+// Shared headless-Chromium lifecycle for all server-side PDF rendering
+// (invoice / report / quote). Previously each render module held its own
+// module-singleton browser, so a backend process kept up to THREE
+// resident Chromiums. On the 1 GB production box that was the structural
+// squeeze behind the 2026-06-04 OOM hard-lock (see docs/postmortem.md):
+// three ~300-500 MB browsers left no headroom alongside Postgres + nginx
+// + Docker + two Node apps.
+//
+// This module is the single owner of the one shared browser. Render
+// modules go through withPage(); they never launch or close Chromium
+// themselves.
+//
+// Two safeguards against long-run memory creep:
+//   - Periodic recycle: after PUPPETEER_MAX_RENDERS pages or
+//     PUPPETEER_MAX_AGE_MS of uptime, the browser is closed and the next
+//     getBrowser() relaunches a fresh one. Chromium leaks slowly across
+//     many page lifecycles; recycling reclaims it.
+//   - Recycle never fires while a render is in flight (_active > 0), so a
+//     concurrent render can't have its browser yanked mid-pdf.
+
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+
+let _browser: Browser | null = null;
+let _launching: Promise<Browser> | null = null;
+let _renders = 0; // pages rendered on the CURRENT browser
+let _launchedAt = 0; // Date.now() when the current browser launched
+let _active = 0; // renders currently holding a page open
+
+const MAX_RENDERS = Number(process.env.PUPPETEER_MAX_RENDERS ?? 50);
+const MAX_AGE_MS = Number(
+  process.env.PUPPETEER_MAX_AGE_MS ?? 6 * 60 * 60 * 1000,
+);
+
+// --disable-dev-shm-usage is critical in Docker (the default /dev/shm is
+// tiny). --disable-gpu drops the GPU stack we never use. The max-old-space
+// cap keeps V8's heap modest since our pages are small SSR'd documents.
+//
+// NB: --single-process / --no-zygote were tried (postmortem suggested
+// them for a tight box) but reliably HANG page.pdf() in headless
+// Chromium 24 — verified locally. The memory win comes from sharing one
+// browser + recycling, not from collapsing Chromium's process model.
+const LAUNCH_ARGS = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-gpu',
+  '--js-flags=--max-old-space-size=256',
+];
+
+async function launch(): Promise<Browser> {
+  const browser = await puppeteer.launch({ headless: true, args: LAUNCH_ARGS });
+  _browser = browser;
+  _renders = 0;
+  _launchedAt = Date.now();
+  return browser;
+}
+
+export async function getBrowser(): Promise<Browser> {
+  if (_browser) return _browser;
+  // Collapse concurrent first-launch races onto one launch() promise.
+  if (!_launching) {
+    _launching = launch().finally(() => {
+      _launching = null;
+    });
+  }
+  return _launching;
+}
+
+export async function closeBrowser(): Promise<void> {
+  const browser = _browser;
+  _browser = null;
+  if (browser) await browser.close();
+}
+
+// Recycle is fire-and-forget on purpose. We swap the browser reference
+// out synchronously (so the next getBrowser() launches a fresh one) and
+// close the old one in the background. The render path must NEVER await
+// browser.close(): Chromium teardown can be slow or wedge, and blocking
+// a render's finally on it would hang the HTTP response. The old browser
+// has no in-flight pages here (_active === 0), so detaching it is safe.
+function maybeRecycle(): void {
+  if (_active > 0 || !_browser) return;
+  const aged = Date.now() - _launchedAt >= MAX_AGE_MS;
+  const spent = _renders >= MAX_RENDERS;
+  if (!(aged || spent)) return;
+  const old = _browser;
+  _browser = null;
+  void old.close().catch(() => {});
+}
+
+// Acquire a fresh page on the shared browser, run fn, and always close
+// the page + advance the recycle bookkeeping. This is the only entry
+// point render modules should use.
+export async function withPage<T>(fn: (page: Page) => Promise<T>): Promise<T> {
+  const browser = await getBrowser();
+  _active++;
+  const page = await browser.newPage();
+  try {
+    return await fn(page);
+  } finally {
+    await page.close().catch(() => {});
+    _active--;
+    _renders++;
+    maybeRecycle();
+  }
+}

--- a/server/lib/quote-pdf.ts
+++ b/server/lib/quote-pdf.ts
@@ -6,11 +6,9 @@
 // Builds depend on `npm run build:quote-template` (in client/) having
 // produced quote-template-dist/{QuoteTemplate.js,QuoteTemplate.css}.
 //
-// The browser singleton is intentionally separate from pdf.ts's so this
-// module has no import dependency on the invoice render path. Launching
-// a second Chromium is the cost of that isolation; quote volume is low.
+// The headless Chromium is shared with the invoice/report render paths
+// via lib/puppeteer.ts.
 
-import puppeteer, { type Browser } from 'puppeteer';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 import { readFile } from 'node:fs/promises';
@@ -18,6 +16,11 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import db from '../db/index.js';
 import { putObject, getObjectBytes } from './s3.js';
+import { withPage, closeBrowser } from './puppeteer.js';
+
+// Kept under the old name in case a caller imports it; the browser now
+// lives in lib/puppeteer.ts.
+export const closeQuoteBrowser = closeBrowser;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -28,26 +31,9 @@ const BUNDLE_DIR =
 const BUNDLE_JS = path.join(BUNDLE_DIR, 'QuoteTemplate.js');
 const BUNDLE_CSS = path.join(BUNDLE_DIR, 'QuoteTemplate.css');
 
-let _browser: Browser | null = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _template: any = null;
 let _css: string | null = null;
-
-async function getBrowser(): Promise<Browser> {
-  if (_browser) return _browser;
-  _browser = await puppeteer.launch({
-    headless: true,
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
-  });
-  return _browser;
-}
-
-export async function closeQuoteBrowser(): Promise<void> {
-  if (_browser) {
-    await _browser.close();
-    _browser = null;
-  }
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getTemplate(): Promise<any> {
@@ -201,9 +187,7 @@ export async function renderQuotePdf(quoteId: number): Promise<Buffer> {
   const css = await getCss();
   const ssrHtml = renderToString(createElement(Template, { data }));
   const html = wrapHtml(ssrHtml, css);
-  const browser = await getBrowser();
-  const page = await browser.newPage();
-  try {
+  return withPage(async (page) => {
     await page.setContent(html, { waitUntil: 'load' });
     await page.evaluate(() => document.fonts.ready);
     const pdf = await page.pdf({
@@ -212,9 +196,7 @@ export async function renderQuotePdf(quoteId: number): Promise<Buffer> {
       margin: { top: 0, right: 0, bottom: 0, left: 0 },
     });
     return Buffer.from(pdf);
-  } finally {
-    await page.close();
-  }
+  });
 }
 
 export function quotePdfS3Key(quoteId: number): string {

--- a/server/lib/report-pdf.ts
+++ b/server/lib/report-pdf.ts
@@ -13,13 +13,18 @@
 // Builds depend on `npm run build:report-templates` (in client/)
 // producing server/report-template-dist/{ReportTemplate.js,.css}.
 
-import puppeteer, { type Browser } from 'puppeteer';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { putObject, getObjectBytes } from './s3.js';
+import { withPage, closeBrowser } from './puppeteer.js';
+
+// The browser now lives in lib/puppeteer.ts. Kept under the old name so
+// scripts (smoke-report-pdf, smoke-release-summary) that import
+// closeReportBrowser from here keep working.
+export const closeReportBrowser = closeBrowser;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,30 +35,9 @@ const BUNDLE_DIR =
 const BUNDLE_JS = path.join(BUNDLE_DIR, 'ReportTemplate.js');
 const BUNDLE_CSS = path.join(BUNDLE_DIR, 'ReportTemplate.css');
 
-let _browser: Browser | null = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _template: any = null;
 let _css: string | null = null;
-
-async function getBrowser(): Promise<Browser> {
-  if (_browser) return _browser;
-  _browser = await puppeteer.launch({
-    headless: true,
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-      '--disable-dev-shm-usage',
-    ],
-  });
-  return _browser;
-}
-
-export async function closeReportBrowser(): Promise<void> {
-  if (_browser) {
-    await _browser.close();
-    _browser = null;
-  }
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getTemplate(): Promise<any> {
@@ -101,10 +85,8 @@ export async function renderReportPdf(
     createElement(Template, { type: reportType, data }),
   );
   const html = wrapHtml(ssrHtml, css);
-  log(`html=${html.length} bytes, launching browser`);
-  const browser = await getBrowser();
-  const page = await browser.newPage();
-  try {
+  log(`html=${html.length} bytes, acquiring page`);
+  return withPage(async (page) => {
     await page.setContent(html, { waitUntil: 'load' });
     await page.evaluate(() => document.fonts.ready);
     const pdf = await page.pdf({
@@ -114,9 +96,7 @@ export async function renderReportPdf(
     });
     log(`pdf=${pdf.length} bytes`);
     return Buffer.from(pdf);
-  } finally {
-    await page.close();
-  }
+  });
 }
 
 export function reportPdfS3Key(reportId: number): string {

--- a/server/scripts/prod-diagnose.sh
+++ b/server/scripts/prod-diagnose.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Read-only diagnostic snapshot of prod state, for the bugs reported
+# on 2026-06-06 (quote_lines crash + quote email non-delivery).
+#
+# Pulls only what we need to answer:
+#   A. Does the quote_line_items table exist (and quote_lines NOT) on prod?
+#   B. Did migrations 0018/0022/0023 actually land on prod?
+#   C. What state is the affected box (FAMU 827164-0) and its quote in?
+#   D. Are any quote/invoice sends in flight or stuck?
+#
+# Output: ~/airtight-cutover/diagnose-YYYYMMDD-HHMMSS/
+#   schema-quote.sql              \pg_dump schema-only for quote_* tables
+#   schema-pickup.sql             \pg_dump schema-only for pickup_* tables
+#   info-schema-summary.txt       \one row per relevant table
+#   migrations-applied.txt        \drizzle journal (if present)
+#   famu-827164-0.txt             \box history for the operator's case
+#   recent-quotes.txt             \last 20 quotes + send status
+#   send-bcc-env.txt              \what SEND_BCC and RESEND prefix are on host
+#
+# Safe to re-run. Does not mutate prod.
+set -euo pipefail
+
+SSH_KEY="${HOME}/airtight.pem"
+SSH_HOST="ubuntu@airtightshippingcontainer.com"
+PROD_DB="containers_prod"
+
+TS="$(date -u +%Y%m%d-%H%M%S)"
+OUT_DIR="${HOME}/airtight-cutover/diagnose-${TS}"
+mkdir -p "${OUT_DIR}"
+
+echo "[diagnose] output dir: ${OUT_DIR}"
+
+ssh_psql() {
+  # Quote-safe single-query runner against prod.
+  local q="$1"
+  ssh -i "${SSH_KEY}" "${SSH_HOST}" \
+    "sudo -u postgres psql -d ${PROD_DB} -v ON_ERROR_STOP=1 -P pager=off -c \"$q\""
+}
+
+ssh_psql_file() {
+  # Run a heredoc-style script. Pass the SQL on stdin.
+  ssh -i "${SSH_KEY}" "${SSH_HOST}" \
+    "sudo -u postgres psql -d ${PROD_DB} -v ON_ERROR_STOP=1 -P pager=off -A -F $'\t'"
+}
+
+echo "[diagnose] A. schema for quote_*, pickup_*, sh_inventory"
+ssh -i "${SSH_KEY}" "${SSH_HOST}" "
+  sudo -u postgres pg_dump -d ${PROD_DB} --schema-only \
+    -t 'quote*' -t 'pickup*' -t 'sh_inventory' -t 'invoices' -t 'invoice_*' 2>/dev/null
+" > "${OUT_DIR}/schema-quote.sql"
+
+echo "[diagnose] B. table presence / column shape"
+ssh_psql_file > "${OUT_DIR}/info-schema-summary.txt" <<'SQL'
+\echo === existence check ===
+SELECT table_name
+  FROM information_schema.tables
+ WHERE table_schema = 'public'
+   AND table_name IN (
+     'quotes','quote_line_items','quote_lines',
+     'quote_line_modifications',
+     'pickup_numbers','pickup_number_assignments','sh_inventory',
+     'invoices','invoice_lines','invoice_line_items'
+   )
+ ORDER BY table_name;
+
+\echo === quote_line_items columns ===
+SELECT column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema='public' AND table_name='quote_line_items'
+ ORDER BY ordinal_position;
+
+\echo === pickup_numbers columns (0022) ===
+SELECT column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema='public' AND table_name='pickup_numbers'
+ ORDER BY ordinal_position;
+
+\echo === sh_inventory pickup_damage (0022) ===
+SELECT column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema='public' AND table_name='sh_inventory'
+   AND column_name IN ('pickup_damage','pickup_number_id')
+ ORDER BY ordinal_position;
+
+\echo === trigger from 0023 ===
+SELECT trigger_name, event_manipulation, action_timing
+  FROM information_schema.triggers
+ WHERE event_object_schema='public'
+   AND event_object_table='pickup_number_assignments';
+SQL
+
+echo "[diagnose] B'. drizzle journal (if used)"
+ssh_psql_file > "${OUT_DIR}/migrations-applied.txt" <<'SQL'
+SELECT to_regclass('public.__drizzle_migrations') AS drizzle_table;
+\if :{?drizzle_table}
+\echo (drizzle table existed; dumping)
+SELECT * FROM __drizzle_migrations ORDER BY id;
+\endif
+SQL
+
+echo "[diagnose] C. FAMU 827164-0 history (the box in the operator report)"
+ssh_psql_file > "${OUT_DIR}/famu-827164-0.txt" <<'SQL'
+\echo === inventory row(s) for FAMU 827164-0 ===
+SELECT id, unit_number, status, created_at, deleted_at
+  FROM inventory
+ WHERE trim(unit_number) = 'FAMU 827164-0';
+
+\echo === quotes referencing this unit (line description match) ===
+SELECT q.id, q.quote_number, q.status, q.sent_at, q.created_at,
+       q.client_id, li.id AS line_id, li.description, li.sale_price
+  FROM quotes q
+  LEFT JOIN quote_line_items li ON li.quote_id = q.id
+ WHERE q.deleted_at IS NULL
+   AND (li.description ILIKE '%827164%' OR li.description ILIKE '%FAMU 8271%')
+ ORDER BY q.id DESC
+ LIMIT 20;
+
+\echo === any sold/release rows referencing this unit ===
+SELECT 'sold' AS src, id::text, outbound_date::text, inbound_date::text
+  FROM sold
+ WHERE inventory_id IN (SELECT id FROM inventory WHERE trim(unit_number) = 'FAMU 827164-0')
+ ORDER BY id DESC
+ LIMIT 10;
+SQL
+
+echo "[diagnose] D. recent quote send activity (deliverability sanity)"
+ssh_psql_file > "${OUT_DIR}/recent-quotes.txt" <<'SQL'
+\echo === last 20 quotes: sent_at, status, customer email domain ===
+SELECT q.id, q.quote_number, q.status, q.sent_at,
+       split_part(cl.contact_email, '@', 2) AS recipient_domain,
+       q.created_at
+  FROM quotes q
+  JOIN clients cl ON q.client_id = cl.id
+ WHERE q.deleted_at IS NULL
+ ORDER BY q.id DESC
+ LIMIT 20;
+
+\echo === quotes that were generated but never marked sent ===
+SELECT q.id, q.quote_number, q.status, q.created_at,
+       split_part(cl.contact_email, '@', 2) AS recipient_domain
+  FROM quotes q
+  JOIN clients cl ON q.client_id = cl.id
+ WHERE q.deleted_at IS NULL
+   AND q.sent_at IS NULL
+   AND q.created_at > NOW() - INTERVAL '14 days'
+ ORDER BY q.id DESC;
+SQL
+
+echo "[diagnose] E. host env (SEND_BCC + RESEND key prefix, NOT the key)"
+ssh -i "${SSH_KEY}" "${SSH_HOST}" '
+  set +x
+  cd ~/airtight-container || exit 0
+  grep -E "^(SEND_BCC|RESEND|CORS_ORIGIN|BETTER_AUTH_URL)" .env 2>/dev/null \
+    | sed "s/\(RESEND=re_[a-zA-Z0-9]\{6\}\).*/\1…/"
+  echo "---"
+  docker compose ps 2>/dev/null
+  echo "---"
+  docker compose exec -T backend printenv 2>/dev/null \
+    | grep -E "^(SEND_BCC|RESEND|NODE_ENV)" \
+    | sed "s/\(RESEND=re_[a-zA-Z0-9]\{6\}\).*/\1…/"
+' > "${OUT_DIR}/send-bcc-env.txt" 2>&1
+
+echo "[diagnose] F. backend log tail (Resend errors in last 24h)"
+ssh -i "${SSH_KEY}" "${SSH_HOST}" '
+  docker logs --since 24h airtight-container-backend-1 2>&1 \
+    | grep -E "quote\.email|quote\.promote|resend|Resend|quote_lines" \
+    | tail -200
+' > "${OUT_DIR}/recent-backend-errors.txt" 2>&1 || true
+
+echo ""
+echo "[diagnose] done. Artifacts in:"
+echo "  ${OUT_DIR}"
+ls -la "${OUT_DIR}"

--- a/server/tests/lib/sh-checkout.test.ts
+++ b/server/tests/lib/sh-checkout.test.ts
@@ -39,6 +39,10 @@ const seed = async (state: 'in_storage' | 'checked_out' = 'in_storage') => {
   const cl = await pool.query(
     `INSERT INTO clients (client_name) VALUES ('Test Customer') RETURNING id`,
   );
+  // intake_date is a FIXED date before the May-2026 billing windows the
+  // tests below assert against — NOT now()-relative. A relative intake
+  // would drift past those hardcoded windows once the wall clock moved
+  // (e.g. the visibility test broke for every run after 2026-06-05).
   const box = await pool.query(
     `INSERT INTO sh_inventory (
        client_id, release_number_id, unit_number, size,
@@ -47,7 +51,7 @@ const seed = async (state: 'in_storage' | 'checked_out' = 'in_storage') => {
      ) VALUES (
        $1, $2, 'TCKU-CHKOUT-' || floor(random() * 1e9)::text, '20ft',
        'in_out_daily', '65', '65', '1',
-       $3::sh_state, false, now() - interval '5 days'
+       $3::sh_state, false, '2026-04-01'
      ) RETURNING id`,
     [cl.rows[0].id, rn.rows[0].release_number_id, state],
   );


### PR DESCRIPTION
## Why

Remediation for the **2026-06-04 EC2 hard-lock** (`docs/postmortem.md`). The backend held up to **three** module-singleton Chromium instances — one each in `lib/pdf.ts` (invoice), `lib/report-pdf.ts` (reports), `lib/quote-pdf.ts` (quotes). On the 1 GB box that resident footprint (~300–500 MB each) left no headroom alongside Postgres + nginx + Docker + two Node apps, and was the structural cause of the OOM freeze. Swap is already deployed as the immediate seatbelt; this is the code-level cure + blast-radius cap.

## What

- **`lib/puppeteer.ts` (new)** — single shared headless Chromium, owned in one place. Render modules call `withPage(fn)`; they no longer launch or close Chromium themselves. The old `closeBrowser` / `closeReportBrowser` / `closeQuoteBrowser` names are kept as re-export aliases so the smoke/rerender scripts that import them still work.
- **Periodic recycle** — after `PUPPETEER_MAX_RENDERS` (default 50) pages or `PUPPETEER_MAX_AGE_MS` (default 6h), the browser is closed and the next render relaunches a fresh one, reclaiming Chromium's slow cross-page memory creep. The recycle close is **fire-and-forget**: the render path never awaits `browser.close()` (it can wedge — see below — and awaiting it in a `finally` would hang the HTTP response). Recycle only fires when no render is in flight.
- **Dropped `--single-process` / `--no-zygote`** — the postmortem suggested them, but I verified locally they **hang `page.pdf()`** in headless Chromium 24 (the render never returns). Kept `--disable-dev-shm-usage` (critical in Docker), `--disable-gpu`, and a V8 `--max-old-space-size=256` cap.
- **`docker-compose.yml`** — backend `mem_limit: 600m`. A render spike now OOM-kills and restarts the container in isolation instead of dragging the host into a hard lock.
- **`sh-checkout.test.ts` flake fix** — the fixture seeded `intake_date = now() - 5 days` against hardcoded May-2026 billing windows, so any run after 2026-06-05 failed the visibility assertion. Pinned `intake_date` to `2026-04-01`.
- Also bundles the read-only `server/scripts/prod-diagnose.sh` and the `docs/postmortem.md` the code comments reference.

## Testing

- Invoice render via `smoke-pdf.ts` → valid 1-page, 163 KB PDF in ~450 ms.
- Reuse + recycle harness: 3 renders with `PUPPETEER_MAX_RENDERS=2` → browser reused for renders 1–2, recycled exactly once before render 3, **no hang**, clean exit.
- `npm test`: **226/226**. `tsc --noEmit` clean.

## Post-deploy verification

- `docker inspect airtight-container-backend-1 --format '{{.HostConfig.Memory}}'` → `629145600`.
- `docker stats` under light traffic for ~30 min: RSS plateaus, not climbs.
- Generate a few quote/invoice/report PDFs; `docker exec ... ps -ef | grep chromium` shows a single browser that recycles cleanly.

## Follow-up (not in this PR)

- Instance bump to t3.small (2 GB) — postmortem floor; deferred for a week of observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
