### PR TITLE
Feat: $0 sale price, copy-line-above, draft autosave

### DIFF
--- a/client/src/components/forms/QuoteEditor.tsx
+++ b/client/src/components/forms/QuoteEditor.tsx
@@ -101,22 +101,36 @@ export default function QuoteEditor({ initial, onCancel, onSave }: QuoteEditorPr
     }));
   };
 
+  // "+ Add line item" copies the line above (deep-copying modifications
+  // with fresh client-side ids) so similar lines don't have to be
+  // retyped. Falls back to a blank line when there's nothing to copy.
   const addLine = () => {
-    setDraft((d) => ({
-      ...d,
-      lines: [
-        ...d.lines,
-        {
-          id: newKey(),
-          description: '',
-          sale_price: null,
-          trucking_rate: null,
-          destination: null,
-          position: d.lines.length,
-          modifications: [],
-        },
-      ],
-    }));
+    setDraft((d) => {
+      const last = d.lines[d.lines.length - 1];
+      const lineKey = newKey();
+      const copied = last
+        ? {
+            ...last,
+            id: lineKey,
+            position: d.lines.length,
+            modifications: last.modifications.map((m, i) => ({
+              ...m,
+              id: -Date.now() - i,
+              quote_line_item_id: lineKey,
+              position: i,
+            })),
+          }
+        : {
+            id: lineKey,
+            description: '',
+            sale_price: null,
+            trucking_rate: null,
+            destination: null,
+            position: d.lines.length,
+            modifications: [],
+          };
+      return { ...d, lines: [...d.lines, copied] };
+    });
   };
 
   const removeLine = (id: number) =>

--- a/client/src/lib/useDraftPersistence.ts
+++ b/client/src/lib/useDraftPersistence.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Auto-persist an in-progress form to localStorage so a refresh, a
+// misclick, or an iPad backgrounding the tab doesn't lose a half-filled
+// quote/invoice. Complements useDirtyForm (which only *warns* on
+// navigation) — this actually saves and restores.
+//
+// Usage:
+//   const { hasDraft, clearDraft } = useDraftPersistence(
+//     'airtight:draft:quote-create',
+//     snapshot,          // a plain serializable object of the live form state
+//     (saved) => { ...setState from saved... },  // restore, called once on mount
+//   );
+// Call clearDraft() on successful submit; wire a "Discard draft" button
+// to clearDraft() + your own form reset.
+export function useDraftPersistence<T>(
+  key: string,
+  snapshot: T,
+  onRestore: (saved: T) => void,
+) {
+  const [hasDraft, setHasDraft] = useState(false);
+  // Suppress the write effect until the one-time restore has run, so the
+  // empty initial render can't clobber a saved draft.
+  const writesEnabled = useRef(false);
+  // onRestore is captured once; callers pass an inline closure that we
+  // don't want to re-run on every render.
+  const restoreRef = useRef(onRestore);
+  restoreRef.current = onRestore;
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        restoreRef.current(JSON.parse(raw) as T);
+        setHasDraft(true);
+      }
+    } catch {
+      // Corrupt/incompatible draft — drop it rather than wedge the form.
+      localStorage.removeItem(key);
+    }
+    // Enable writes after the restore-triggered state updates have flushed.
+    const t = setTimeout(() => {
+      writesEnabled.current = true;
+    }, 0);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  useEffect(() => {
+    if (!writesEnabled.current) return;
+    const t = setTimeout(() => {
+      try {
+        localStorage.setItem(key, JSON.stringify(snapshot));
+        setHasDraft(true);
+      } catch {
+        // Quota or non-serializable value — best-effort, ignore.
+      }
+    }, 500);
+    return () => clearTimeout(t);
+  }, [key, snapshot]);
+
+  const clearDraft = useCallback(() => {
+    localStorage.removeItem(key);
+    setHasDraft(false);
+  }, [key]);
+
+  return { hasDraft, clearDraft };
+}

--- a/client/src/routes/CreateInvoice.module.css
+++ b/client/src/routes/CreateInvoice.module.css
@@ -20,6 +20,12 @@
   font-weight: 600;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .stepLabel {
   font-size: 0.875rem;
   color: var(--muted);

--- a/client/src/routes/CreateInvoice.tsx
+++ b/client/src/routes/CreateInvoice.tsx
@@ -13,6 +13,7 @@ import {
 import { AddClientModal } from '../components/forms/AddClientModal';
 import { DoorOrientationField } from '../components/forms/DoorOrientationField';
 import { useDirtyForm } from '../lib/useDirtyForm';
+import { useDraftPersistence } from '../lib/useDraftPersistence';
 import InvoiceTemplate from '../components/templates/invoice/InvoiceTemplate';
 import { fmtCurrency, fmtDate } from '../components/templates/invoice/format';
 import type {
@@ -180,6 +181,69 @@ export default function CreateInvoice() {
     submitState.kind !== 'done' &&
       (selectedIds.length > 0 || selectedClient !== null),
   );
+
+  const draftSnapshot = useMemo(
+    () => ({
+      step,
+      selectedIds,
+      drafts,
+      selectedClient,
+      invoiceTaxed,
+      invoiceCredit,
+      taxRate,
+      ccFeePct,
+      invoiceDate,
+      shipSameAsBilling,
+      shipTo,
+    }),
+    [
+      step,
+      selectedIds,
+      drafts,
+      selectedClient,
+      invoiceTaxed,
+      invoiceCredit,
+      taxRate,
+      ccFeePct,
+      invoiceDate,
+      shipSameAsBilling,
+      shipTo,
+    ],
+  );
+  const { hasDraft, clearDraft } = useDraftPersistence(
+    'airtight:draft:invoice-create',
+    draftSnapshot,
+    (saved) => {
+      if (saved.step != null) setStep(saved.step);
+      if (Array.isArray(saved.selectedIds)) setSelectedIds(saved.selectedIds);
+      if (saved.drafts) setDrafts(saved.drafts);
+      if (saved.selectedClient !== undefined)
+        setSelectedClient(saved.selectedClient);
+      if (saved.invoiceTaxed != null) setInvoiceTaxed(saved.invoiceTaxed);
+      if (saved.invoiceCredit != null) setInvoiceCredit(saved.invoiceCredit);
+      if (saved.taxRate != null) setTaxRate(saved.taxRate);
+      if (saved.ccFeePct != null) setCcFeePct(saved.ccFeePct);
+      if (saved.invoiceDate != null) setInvoiceDate(saved.invoiceDate);
+      if (saved.shipSameAsBilling != null)
+        setShipSameAsBilling(saved.shipSameAsBilling);
+      if (saved.shipTo) setShipTo(saved.shipTo);
+    },
+  );
+
+  const discardDraft = () => {
+    clearDraft();
+    setStep(0);
+    setSelectedIds([]);
+    setDrafts({});
+    setSelectedClient(null);
+    setInvoiceTaxed(false);
+    setInvoiceCredit(false);
+    setTaxRate('0.06625');
+    setCcFeePct('3.5');
+    setInvoiceDate(todayISO());
+    setShipSameAsBilling(true);
+    setShipTo({ name: '', street: '', city: '', state: '', zip: '' });
+  };
 
   const loadTruckingCompanies = async () => {
     try {
@@ -505,7 +569,11 @@ export default function CreateInvoice() {
     if (step === 2) {
       return selectedIds.every((id) => {
         const d = drafts[id];
-        return d && Number(d.sale_price || 0) > 0;
+        return (
+          d &&
+          d.sale_price.trim() !== '' &&
+          Number.isFinite(Number(d.sale_price))
+        );
       });
     }
     return true;
@@ -608,6 +676,7 @@ export default function CreateInvoice() {
         throw new Error(body?.message ?? 'Save failed');
       }
 
+      clearDraft();
       setSubmitState({ kind: 'done', id: created.id, invoice_number: created.invoice_number });
       setStep(4);
     } catch (e) {
@@ -625,9 +694,16 @@ export default function CreateInvoice() {
     <div className={styles.page}>
       <header className={styles.header}>
         <h1 className={styles.title}>New Invoice</h1>
-        <span className={styles.stepLabel}>
-          Step {Math.min(step + 1, STEP_NAMES.length)} of {STEP_NAMES.length}
-        </span>
+        <div className={styles.headerActions}>
+          {hasDraft && submitState.kind !== 'done' && (
+            <Button variant="secondary" onClick={discardDraft}>
+              Discard draft
+            </Button>
+          )}
+          <span className={styles.stepLabel}>
+            Step {Math.min(step + 1, STEP_NAMES.length)} of {STEP_NAMES.length}
+          </span>
+        </div>
       </header>
 
       <Stepper labels={STEP_NAMES} current={step} ariaLabel="Invoice progress" />
@@ -745,7 +821,8 @@ export default function CreateInvoice() {
           <FlowStep>
             <p className={styles.hint}>
               Fill in per-container prices and invoice-level charges. Totals
-              update live. Sale price is required on every container.
+              update live. Sale price is required on every container (0 is
+              allowed).
             </p>
             <div className={styles.invoiceMetaGrid}>
               <label className={styles.field}>

--- a/client/src/routes/CreateQuote.module.css
+++ b/client/src/routes/CreateQuote.module.css
@@ -20,6 +20,12 @@
   font-weight: 600;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .stepLabel {
   font-size: 0.875rem;
   color: var(--muted);

--- a/client/src/routes/CreateQuote.tsx
+++ b/client/src/routes/CreateQuote.tsx
@@ -12,6 +12,7 @@ import {
 import { AddClientModal } from '../components/forms/AddClientModal';
 import { DestinationField } from '../components/forms/DestinationField';
 import { useDirtyForm } from '../lib/useDirtyForm';
+import { useDraftPersistence } from '../lib/useDraftPersistence';
 import QuoteTemplate from '../components/templates/quote/QuoteTemplate';
 import { fmtCurrency, fmtDate } from '../components/templates/quote/format';
 import type {
@@ -111,6 +112,59 @@ export default function CreateQuote() {
     submitState.kind !== 'done' &&
       (selectedClient !== null || notes.trim() !== ''),
   );
+
+  const draftSnapshot = useMemo(
+    () => ({
+      step,
+      selectedClient,
+      lines,
+      notes,
+      quoteTaxed,
+      quoteCredit,
+      taxRate,
+      ccFeePct,
+    }),
+    [step, selectedClient, lines, notes, quoteTaxed, quoteCredit, taxRate, ccFeePct],
+  );
+  const { hasDraft, clearDraft } = useDraftPersistence(
+    'airtight:draft:quote-create',
+    draftSnapshot,
+    (saved) => {
+      if (saved.step != null) setStep(saved.step);
+      if (saved.selectedClient !== undefined)
+        setSelectedClient(saved.selectedClient);
+      // Re-key restored lines + mods so module-level keySeq can't later
+      // mint a colliding negative key for a freshly added line.
+      if (Array.isArray(saved.lines))
+        setLines(
+          saved.lines.map((l) => ({
+            ...l,
+            key: keySeq--,
+            modifications: l.modifications.map((m, i) => ({
+              ...m,
+              id: -Date.now() - i,
+            })),
+          })),
+        );
+      if (saved.notes != null) setNotes(saved.notes);
+      if (saved.quoteTaxed != null) setQuoteTaxed(saved.quoteTaxed);
+      if (saved.quoteCredit != null) setQuoteCredit(saved.quoteCredit);
+      if (saved.taxRate != null) setTaxRate(saved.taxRate);
+      if (saved.ccFeePct != null) setCcFeePct(saved.ccFeePct);
+    },
+  );
+
+  const discardDraft = () => {
+    clearDraft();
+    setStep(0);
+    setSelectedClient(null);
+    setLines([blankLine()]);
+    setNotes('');
+    setQuoteTaxed(false);
+    setQuoteCredit(false);
+    setTaxRate('0.06625');
+    setCcFeePct('3.5');
+  };
 
   useEffect(() => {
     (async () => {
@@ -234,7 +288,26 @@ export default function CreateQuote() {
     setLines((prev) => prev.map((l) => (l.key === key ? { ...l, ...patch } : l)));
   };
 
-  const addLine = () => setLines((prev) => [...prev, blankLine()]);
+  // "+ Add line item" copies the line above so repeated, similar lines
+  // (same container size/price, tweak one field) don't have to be retyped.
+  // Modifications are deep-copied with fresh client-side ids. Falls back
+  // to a blank line when there's nothing to copy.
+  const addLine = () =>
+    setLines((prev) => {
+      const last = prev[prev.length - 1];
+      if (!last) return [...prev, blankLine()];
+      return [
+        ...prev,
+        {
+          ...last,
+          key: keySeq--,
+          modifications: last.modifications.map((m, i) => ({
+            ...m,
+            id: -Date.now() - i,
+          })),
+        },
+      ];
+    });
 
   const removeLine = (key: number) =>
     setLines((prev) => prev.filter((l) => l.key !== key));
@@ -308,7 +381,11 @@ export default function CreateQuote() {
     if (step === 1) {
       return (
         validLines.length > 0 &&
-        validLines.every((l) => Number(l.sale_price || 0) > 0)
+        validLines.every(
+          (l) =>
+            l.sale_price.trim() !== '' &&
+            Number.isFinite(Number(l.sale_price)),
+        )
       );
     }
     return true;
@@ -350,6 +427,7 @@ export default function CreateQuote() {
         throw new Error(body?.message ?? 'Create failed');
       }
       const created = (await res.json()) as { id: number; quote_number: string };
+      clearDraft();
       setSubmitState({
         kind: 'done',
         id: created.id,
@@ -371,9 +449,16 @@ export default function CreateQuote() {
     <div className={styles.page}>
       <header className={styles.header}>
         <h1 className={styles.title}>New Quote</h1>
-        <span className={styles.stepLabel}>
-          Step {Math.min(step + 1, STEP_NAMES.length)} of {STEP_NAMES.length}
-        </span>
+        <div className={styles.headerActions}>
+          {hasDraft && submitState.kind !== 'done' && (
+            <Button variant="secondary" onClick={discardDraft}>
+              Discard draft
+            </Button>
+          )}
+          <span className={styles.stepLabel}>
+            Step {Math.min(step + 1, STEP_NAMES.length)} of {STEP_NAMES.length}
+          </span>
+        </div>
       </header>
 
       <Stepper labels={STEP_NAMES} current={step} ariaLabel="Quote progress" />


### PR DESCRIPTION
## What

Three operator-requested quote/invoice quick wins. **No migration.**

### 1. Sale price $0 allowed
Both create steppers gated `canAdvance` on `Number(sale_price) > 0`, so a free container couldn't be quoted/invoiced. Relaxed to "a value is present and finite" (`CreateQuote.tsx`, `CreateInvoice.tsx`). The editors and server validation already accept 0.

### 2. "+ Add line item" copies the line above (quotes)
New quote lines pre-fill from the previous line (description, sale price, trucking, destination, and deep-copied modifications with fresh client-side ids) instead of starting blank — so repeated, similar lines aren't retyped. `CreateQuote.tsx` + `QuoteEditor.tsx`. Invoice lines are unique inventory containers, so they're unchanged.

### 3. Draft autosave
New `useDraftPersistence` hook persists the in-progress **create** forms to `localStorage`, auto-restores on return, clears on successful submit, and surfaces a **"Discard draft"** button when a saved draft exists. Wired into `CreateQuote` + `CreateInvoice`. Complements `useDirtyForm` (which only *warns* on navigation).

## Testing
- Client `tsc --noEmit` clean; `npm test` 50/50.
- Manual (local): quote/invoice line at `$0` advances + submits; "+ Add line item" duplicates the previous quote line; leave and return to a create page → form auto-restores; "Discard draft" wipes it; successful submit clears the saved draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
