### PR TITLE
Feat: mod dropdown, quantity, negative prices, quote PDF download (draft)

### DIFF
--- a/client/src/components/forms/InvoiceEditor.test.tsx
+++ b/client/src/components/forms/InvoiceEditor.test.tsx
@@ -155,9 +155,13 @@ describe('InvoiceEditor', () => {
         onSave={() => {}}
       />,
     );
-    expect(screen.getAllByPlaceholderText(/Description \(or pick a preset\)/)).toHaveLength(2);
+    expect(
+      screen.getAllByRole('button', { name: 'Remove modification' }),
+    ).toHaveLength(2);
     await userEvent.click(screen.getByRole('button', { name: '+ Add modification' }));
-    expect(screen.getAllByPlaceholderText(/Description \(or pick a preset\)/)).toHaveLength(3);
+    expect(
+      screen.getAllByRole('button', { name: 'Remove modification' }),
+    ).toHaveLength(3);
   });
 
   it('removing a modification drops its row', async () => {

--- a/client/src/components/forms/InvoiceEditor.test.tsx
+++ b/client/src/components/forms/InvoiceEditor.test.tsx
@@ -63,8 +63,8 @@ const baseInvoice = (over: Partial<InvoiceData> = {}): InvoiceData => ({
       delivery_state: null,
       delivery_zip: null,
       modifications: [
-        { id: 1, sold_id: 10, description: 'Roll-up door', price: '300', position: 0 },
-        { id: 2, sold_id: 10, description: 'Paint', price: '200', position: 1 },
+        { id: 1, sold_id: 10, description: 'Roll-up door', price: '300', quantity: 1, position: 0 },
+        { id: 2, sold_id: 10, description: 'Paint', price: '200', quantity: 1, position: 1 },
       ],
     },
   ],

--- a/client/src/components/forms/InvoiceEditor.tsx
+++ b/client/src/components/forms/InvoiceEditor.tsx
@@ -6,11 +6,7 @@ import type {
 } from '../templates/invoice/types';
 import { AddressFields, Button, CurrencyInput, IconButton } from '../ui';
 import { fmtCurrency } from '../templates/invoice/format';
-import {
-  MODIFICATION_DATALIST_ID,
-  useModPresetLabels,
-  useModPresets,
-} from './modificationPresets';
+import { ModificationRows } from './ModificationRows';
 import { DoorOrientationField } from './DoorOrientationField';
 import styles from './InvoiceEditor.module.css';
 
@@ -69,8 +65,6 @@ export default function InvoiceEditor({
   >([]);
   const [pickerValue, setPickerValue] = useState<string>('');
   const [saving, setSaving] = useState(false);
-  const modPresetLabels = useModPresetLabels();
-  const modPresets = useModPresets();
 
   const loadTruckingCompanies = async () => {
     try {
@@ -174,7 +168,7 @@ export default function InvoiceEditor({
       subtotal += Number(c.sale_price ?? 0);
       subtotal += Number(c.trucking_rate ?? 0);
       const perMod = c.modifications.reduce(
-        (sum, m) => sum + Number(m.price ?? 0),
+        (sum, m) => sum + Number(m.price ?? 0) * (m.quantity || 1),
         0,
       );
       if (perMod > 0) subtotal += perMod;
@@ -274,61 +268,25 @@ export default function InvoiceEditor({
     setPickerValue('');
   };
 
-  const updateMod = (
+  const setContainerMods = (
     ctIdx: number,
-    modIdx: number,
-    patch: Partial<InvoiceModification>,
+    mods: InvoiceModification[],
   ) => {
     setDraft((d) => {
       const containers = d.containers.slice();
-      const mods = containers[ctIdx].modifications.slice();
-      const next = { ...mods[modIdx], ...patch };
-      // Autofill the price when the user picks (or types) a description
-      // matching a preset, but only when the current price is empty/0 —
-      // a typed value wins.
-      if (patch.description !== undefined) {
-        const match = modPresets.find(
-          (p) => p.label === patch.description?.trim(),
-        );
-        const currentPrice = Number(next.price);
-        const priceEmpty =
-          next.price === '' ||
-          next.price == null ||
-          (Number.isFinite(currentPrice) && currentPrice === 0);
-        if (match && match.default_price != null && priceEmpty) {
-          next.price = String(match.default_price);
-        }
-      }
-      mods[modIdx] = next;
       containers[ctIdx] = { ...containers[ctIdx], modifications: mods };
       return { ...d, containers };
     });
   };
 
-  const addMod = (ctIdx: number) => {
-    setDraft((d) => {
-      const containers = d.containers.slice();
-      const mods = containers[ctIdx].modifications.slice();
-      mods.push({
-        id: -Date.now() - mods.length,
-        sold_id: containers[ctIdx].sold_id ?? -1,
-        description: '',
-        price: '0',
-        position: mods.length,
-      });
-      containers[ctIdx] = { ...containers[ctIdx], modifications: mods };
-      return { ...d, containers };
-    });
-  };
-
-  const removeMod = (ctIdx: number, modIdx: number) => {
-    setDraft((d) => {
-      const containers = d.containers.slice();
-      const mods = containers[ctIdx].modifications.filter((_, i) => i !== modIdx);
-      containers[ctIdx] = { ...containers[ctIdx], modifications: mods };
-      return { ...d, containers };
-    });
-  };
+  const blankMod = (ctIdx: number, existing: number): InvoiceModification => ({
+    id: -Date.now() - existing,
+    sold_id: draft.containers[ctIdx].sold_id ?? -1,
+    description: '',
+    price: '0',
+    quantity: 1,
+    position: existing,
+  });
 
   const handleSubmit = async () => {
     setSaving(true);
@@ -343,12 +301,6 @@ export default function InvoiceEditor({
 
   return (
     <div className={styles.editor}>
-      <datalist id={MODIFICATION_DATALIST_ID}>
-        {modPresetLabels.map((d) => (
-          <option key={d} value={d} />
-        ))}
-      </datalist>
-
       <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Invoice</h2>
         <div className={styles.fieldGrid}>
@@ -660,37 +612,11 @@ export default function InvoiceEditor({
               <div className={styles.modsHeader}>
                 <span className={styles.label}>Per-modification line items</span>
               </div>
-              {c.modifications.map((m, mIdx) => (
-                <div key={m.id} className={styles.modRow}>
-                  <input
-                    className={styles.input}
-                    list={MODIFICATION_DATALIST_ID}
-                    placeholder="Description (or pick a preset)"
-                    value={m.description}
-                    onChange={(e) =>
-                      updateMod(ctIdx, mIdx, { description: e.target.value })
-                    }
-                  />
-                  <CurrencyInput
-                    value={m.price}
-                    onChange={(v) => updateMod(ctIdx, mIdx, { price: v })}
-                    placeholder="0.00"
-                  />
-                  <IconButton
-                    icon="trash"
-                    tone="danger"
-                    label="Remove modification"
-                    onClick={() => removeMod(ctIdx, mIdx)}
-                  />
-                </div>
-              ))}
-              <button
-                type="button"
-                className={styles.addRow}
-                onClick={() => addMod(ctIdx)}
-              >
-                + Add modification
-              </button>
+              <ModificationRows
+                mods={c.modifications}
+                onChange={(next) => setContainerMods(ctIdx, next)}
+                makeBlank={() => blankMod(ctIdx, c.modifications.length)}
+              />
             </div>
           </div>
         ))}

--- a/client/src/components/forms/ModificationRows.module.css
+++ b/client/src/components/forms/ModificationRows.module.css
@@ -1,0 +1,62 @@
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* [select (+ custom desc stacked)] | qty | price | trash */
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) 4.5rem 8rem 2.5rem;
+  column-gap: 1rem;
+  align-items: start;
+}
+
+.descCell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.select,
+.desc,
+.qty {
+  padding: 0.45rem 0.625rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 0.9rem;
+  background: var(--bg-input);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.qty {
+  text-align: right;
+}
+
+.select:focus,
+.desc:focus,
+.qty:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+
+.addRow {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: transparent;
+  border: 1.5px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.addRow:hover {
+  border-color: var(--accent);
+  background: var(--hover);
+}

--- a/client/src/components/forms/ModificationRows.tsx
+++ b/client/src/components/forms/ModificationRows.tsx
@@ -1,0 +1,121 @@
+import { CurrencyInput, IconButton } from '../ui';
+import { useModPresets } from './modificationPresets';
+import styles from './ModificationRows.module.css';
+
+// Shared modification-row editor used by every quote/invoice editor
+// (CreateQuote, CreateInvoice, QuoteEditor, InvoiceEditor) so the four
+// stay in lockstep. Replaces the old per-file <datalist> markup, which
+// was awkward on iPad. Here the description is a real <select> of presets
+// with an explicit "Custom (write-in)" default that reveals a free-text
+// field — no hidden typing required.
+//
+// Generic over the caller's mod shape: we only ever touch
+// description/price/quantity and pass the rest through, so callers keep
+// their own extra fields (position, quote_line_item_id, …).
+
+const CUSTOM = '__custom__';
+
+export interface ModLike {
+  id: number;
+  description: string;
+  price: string;
+  quantity: number;
+}
+
+export function ModificationRows<T extends ModLike>({
+  mods,
+  onChange,
+  makeBlank,
+}: {
+  mods: T[];
+  onChange: (next: T[]) => void;
+  /** Factory for a new blank row in the caller's own shape (id scheme,
+   *  position, etc.). Should set quantity = 1. */
+  makeBlank: () => T;
+}) {
+  const presets = useModPresets();
+
+  const patch = (idx: number, p: Partial<ModLike>) =>
+    onChange(mods.map((m, i) => (i === idx ? { ...m, ...p } : m)));
+
+  const onSelect = (idx: number, value: string) => {
+    if (value === CUSTOM) {
+      // Switch to write-in: clear the description so the text field is
+      // ready to type into. Price/quantity left as-is.
+      patch(idx, { description: '' });
+      return;
+    }
+    const preset = presets.find((p) => p.label === value);
+    // Always (re)bind the preset's price — switching presets must update
+    // the price, which the old "only when empty" autofill failed to do.
+    patch(idx, {
+      description: value,
+      price: preset?.default_price != null ? String(preset.default_price) : '0',
+    });
+  };
+
+  return (
+    <div className={styles.rows}>
+      {mods.map((m, idx) => {
+        const isPreset = presets.some((p) => p.label === m.description);
+        const selectValue = isPreset ? m.description : CUSTOM;
+        return (
+          <div key={m.id} className={styles.row}>
+            <div className={styles.descCell}>
+              <select
+                className={styles.select}
+                value={selectValue}
+                onChange={(e) => onSelect(idx, e.target.value)}
+              >
+                <option value={CUSTOM}>Custom (write-in)</option>
+                {presets.map((p) => (
+                  <option key={p.id} value={p.label}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+              {selectValue === CUSTOM && (
+                <input
+                  className={styles.desc}
+                  placeholder="Description"
+                  value={m.description}
+                  onChange={(e) => patch(idx, { description: e.target.value })}
+                />
+              )}
+            </div>
+            <input
+              className={styles.qty}
+              type="number"
+              min={1}
+              step={1}
+              aria-label="Quantity"
+              value={m.quantity ?? 1}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                patch(idx, { quantity: Number.isFinite(n) && n >= 1 ? n : 1 });
+              }}
+            />
+            <CurrencyInput
+              value={m.price}
+              onChange={(v) => patch(idx, { price: v })}
+              placeholder="0.00"
+            />
+            <IconButton
+              icon="trash"
+              tone="danger"
+              label="Remove modification"
+              onClick={() => onChange(mods.filter((_, i) => i !== idx))}
+            />
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className={styles.addRow}
+        onClick={() => onChange([...mods, makeBlank()])}
+      >
+        + Add modification
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/forms/ModificationRows.tsx
+++ b/client/src/components/forms/ModificationRows.tsx
@@ -15,6 +15,12 @@ import styles from './ModificationRows.module.css';
 
 const CUSTOM = '__custom__';
 
+// Quantity is a fixed dropdown (1..20) rather than a number spinner — the
+// up/down arrows are fiddly on iPad, and a dropdown makes a negative
+// quantity impossible by construction. Bump the ceiling if a real job
+// ever needs more than 20 of one modification.
+const QTY_OPTIONS = Array.from({ length: 20 }, (_, i) => i + 1);
+
 export interface ModLike {
   id: number;
   description: string;
@@ -83,18 +89,20 @@ export function ModificationRows<T extends ModLike>({
                 />
               )}
             </div>
-            <input
+            <select
               className={styles.qty}
-              type="number"
-              min={1}
-              step={1}
               aria-label="Quantity"
               value={m.quantity ?? 1}
-              onChange={(e) => {
-                const n = parseInt(e.target.value, 10);
-                patch(idx, { quantity: Number.isFinite(n) && n >= 1 ? n : 1 });
-              }}
-            />
+              onChange={(e) =>
+                patch(idx, { quantity: parseInt(e.target.value, 10) })
+              }
+            >
+              {QTY_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
             <CurrencyInput
               value={m.price}
               onChange={(v) => patch(idx, { price: v })}

--- a/client/src/components/forms/QuoteEditor.tsx
+++ b/client/src/components/forms/QuoteEditor.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, CurrencyInput, IconButton } from '../ui';
+import { Button, IconButton } from '../ui';
 import type { QuoteData } from '../templates/quote/types';
 import { fmtCurrency } from '../templates/quote/format';
-import {
-  MODIFICATION_DATALIST_ID,
-  useModPresetLabels,
-  useModPresets,
-} from './modificationPresets';
+import { ModificationRows } from './ModificationRows';
 import { DestinationField } from './DestinationField';
 import styles from '../../routes/CreateQuote.module.css';
 
@@ -36,8 +32,6 @@ export default function QuoteEditor({ initial, onCancel, onSave }: QuoteEditorPr
   const [draft, setDraft] = useState<QuoteData>(() => structuredClone(initial));
   const [saving, setSaving] = useState(false);
   const [clients, setClients] = useState<ClientSummary[]>([]);
-  const modPresetLabels = useModPresetLabels();
-  const modPresets = useModPresets();
 
   useEffect(() => {
     let cancelled = false;
@@ -82,7 +76,10 @@ export default function QuoteEditor({ initial, onCancel, onSave }: QuoteEditorPr
     for (const l of draft.lines) {
       subtotal += Number(l.sale_price || 0);
       subtotal += Number(l.trucking_rate || 0);
-      subtotal += l.modifications.reduce((s, m) => s + Number(m.price || 0), 0);
+      subtotal += l.modifications.reduce(
+        (s, m) => s + Number(m.price || 0) * (m.quantity || 1),
+        0,
+      );
     }
     const tax = draft.quote_taxed ? subtotal * Number(draft.tax_rate || 0) : 0;
     const cc = draft.quote_credit
@@ -136,69 +133,25 @@ export default function QuoteEditor({ initial, onCancel, onSave }: QuoteEditorPr
   const removeLine = (id: number) =>
     setDraft((d) => ({ ...d, lines: d.lines.filter((l) => l.id !== id) }));
 
-  const addMod = (lineId: number) => {
-    setDraft((d) => ({
-      ...d,
-      lines: d.lines.map((l) =>
-        l.id === lineId
-          ? {
-              ...l,
-              modifications: [
-                ...l.modifications,
-                {
-                  id: -Date.now() - l.modifications.length,
-                  quote_line_item_id: l.id,
-                  description: '',
-                  price: '0',
-                  position: l.modifications.length,
-                },
-              ],
-            }
-          : l,
-      ),
-    }));
-  };
-
-  const updateMod = (
+  const setLineMods = (
     lineId: number,
-    modIdx: number,
-    patch: Partial<{ description: string; price: string }>,
-  ) => {
-    setDraft((d) => ({
-      ...d,
-      lines: d.lines.map((l) => {
-        if (l.id !== lineId) return l;
-        const mods = l.modifications.slice();
-        const next = { ...mods[modIdx], ...patch };
-        if (patch.description !== undefined) {
-          const match = modPresets.find(
-            (p) => p.label === patch.description?.trim(),
-          );
-          const currentPrice = Number(next.price);
-          const priceEmpty =
-            next.price === '' ||
-            next.price == null ||
-            (Number.isFinite(currentPrice) && currentPrice === 0);
-          if (match && match.default_price != null && priceEmpty) {
-            next.price = String(match.default_price);
-          }
-        }
-        mods[modIdx] = next;
-        return { ...l, modifications: mods };
-      }),
-    }));
-  };
-
-  const removeMod = (lineId: number, modIdx: number) => {
+    mods: QuoteData['lines'][number]['modifications'],
+  ) =>
     setDraft((d) => ({
       ...d,
       lines: d.lines.map((l) =>
-        l.id === lineId
-          ? { ...l, modifications: l.modifications.filter((_, i) => i !== modIdx) }
-          : l,
+        l.id === lineId ? { ...l, modifications: mods } : l,
       ),
     }));
-  };
+
+  const blankMod = (lineId: number, existing: number) => ({
+    id: -Date.now() - existing,
+    quote_line_item_id: lineId,
+    description: '',
+    price: '0',
+    quantity: 1,
+    position: existing,
+  });
 
   const save = async () => {
     setSaving(true);
@@ -216,11 +169,6 @@ export default function QuoteEditor({ initial, onCancel, onSave }: QuoteEditorPr
 
   return (
     <div className={styles.body}>
-      <datalist id={MODIFICATION_DATALIST_ID}>
-        {modPresetLabels.map((d) => (
-          <option key={d} value={d} />
-        ))}
-      </datalist>
 
       <div className={styles.containerCard}>
         <div className={styles.containerHead}>
@@ -304,37 +252,11 @@ export default function QuoteEditor({ initial, onCancel, onSave }: QuoteEditorPr
             <div className={styles.modsHeader}>
               <span className={styles.fieldLabel}>Modifications</span>
             </div>
-            {l.modifications.map((m, mIdx) => (
-              <div key={m.id} className={styles.modRow}>
-                <input
-                  className={styles.input}
-                  list={MODIFICATION_DATALIST_ID}
-                  placeholder="Description (or pick a preset)"
-                  value={m.description}
-                  onChange={(e) =>
-                    updateMod(l.id, mIdx, { description: e.target.value })
-                  }
-                />
-                <CurrencyInput
-                  value={m.price}
-                  onChange={(v) => updateMod(l.id, mIdx, { price: v })}
-                  placeholder="0.00"
-                />
-                <IconButton
-                  icon="trash"
-                  tone="danger"
-                  label="Remove modification"
-                  onClick={() => removeMod(l.id, mIdx)}
-                />
-              </div>
-            ))}
-            <button
-              type="button"
-              className={styles.addRow}
-              onClick={() => addMod(l.id)}
-            >
-              + Add modification
-            </button>
+            <ModificationRows
+              mods={l.modifications}
+              onChange={(next) => setLineMods(l.id, next)}
+              makeBlank={() => blankMod(l.id, l.modifications.length)}
+            />
           </div>
         </div>
       ))}

--- a/client/src/components/templates/invoice/InvoiceTemplate.tsx
+++ b/client/src/components/templates/invoice/InvoiceTemplate.tsx
@@ -95,9 +95,13 @@ export default function InvoiceTemplate({ data }: InvoiceTemplateProps) {
                     data-last={si === g.subs.length - 1}
                   >
                     <td className={styles.colN} />
-                    <td className={styles.colQty} />
+                    <td className={styles.colQty}>
+                      {sub.qty > 1 ? sub.qty : ''}
+                    </td>
                     <td className={styles.colDesc}>{sub.description}</td>
-                    <td className={styles.colPrice} />
+                    <td className={styles.colPrice}>
+                      {sub.unitPrice ? fmtCurrency(sub.unitPrice) : ''}
+                    </td>
                     <td className={styles.colTotal}>
                       {sub.lineTotal ? fmtCurrency(sub.lineTotal) : '—'}
                     </td>

--- a/client/src/components/templates/invoice/format.test.ts
+++ b/client/src/components/templates/invoice/format.test.ts
@@ -112,6 +112,7 @@ describe('buildLineGroups', () => {
               sold_id: 10,
               description: 'Roll-up door',
               price: '300',
+              quantity: 1,
               position: 0,
             },
             {
@@ -119,6 +120,7 @@ describe('buildLineGroups', () => {
               sold_id: 10,
               description: 'Paint',
               price: '200',
+              quantity: 1,
               position: 1,
             },
           ],
@@ -172,7 +174,7 @@ describe('buildLineGroups', () => {
           trucking_rate: '400',
           destination: 'Marlboro',
           modifications: [
-            { id: 1, sold_id: 10, description: 'Paint', price: '200', position: 0 },
+            { id: 1, sold_id: 10, description: 'Paint', price: '200', quantity: 1, position: 0 },
           ],
         }),
       ]),

--- a/client/src/components/templates/invoice/format.ts
+++ b/client/src/components/templates/invoice/format.ts
@@ -111,11 +111,12 @@ export const buildLineGroups = (data: InvoiceData): InvoiceLineGroup[] => {
     const mods = Array.isArray(c.modifications) ? c.modifications : [];
     if (mods.length > 0) {
       for (const m of mods) {
+        const qty = m.quantity || 1;
         subs.push({
-          qty: 1,
+          qty,
           description: m.description,
-          unitPrice: null,
-          lineTotal: m.price,
+          unitPrice: qty > 1 ? m.price : null,
+          lineTotal: String(Number(m.price ?? 0) * qty),
         });
       }
     } else {

--- a/client/src/components/templates/invoice/types.ts
+++ b/client/src/components/templates/invoice/types.ts
@@ -20,6 +20,7 @@ export interface InvoiceModification {
   sold_id: number;
   description: string;
   price: string;
+  quantity: number;
   position: number;
 }
 

--- a/client/src/components/templates/quote/QuoteTemplate.tsx
+++ b/client/src/components/templates/quote/QuoteTemplate.tsx
@@ -85,9 +85,13 @@ export default function QuoteTemplate({ data }: QuoteTemplateProps) {
                     data-last={si === g.subs.length - 1}
                   >
                     <td className={styles.colN} />
-                    <td className={styles.colQty} />
+                    <td className={styles.colQty}>
+                      {sub.qty > 1 ? sub.qty : ''}
+                    </td>
                     <td className={styles.colDesc}>{sub.description}</td>
-                    <td className={styles.colPrice} />
+                    <td className={styles.colPrice}>
+                      {sub.unitPrice ? fmtCurrency(sub.unitPrice) : ''}
+                    </td>
                     <td className={styles.colTotal}>
                       {sub.lineTotal ? fmtCurrency(sub.lineTotal) : '—'}
                     </td>

--- a/client/src/components/templates/quote/format.ts
+++ b/client/src/components/templates/quote/format.ts
@@ -26,11 +26,12 @@ export const buildQuoteLineGroups = (data: QuoteData): QuoteLineGroup[] => {
     const subs: QuoteLineRow[] = [];
     const mods = Array.isArray(line.modifications) ? line.modifications : [];
     for (const m of mods) {
+      const qty = m.quantity || 1;
       subs.push({
-        qty: 1,
+        qty,
         description: m.description,
-        unitPrice: null,
-        lineTotal: m.price,
+        unitPrice: qty > 1 ? m.price : null,
+        lineTotal: String(Number(m.price ?? 0) * qty),
       });
     }
     const truck = Number(line.trucking_rate ?? 0);

--- a/client/src/components/templates/quote/types.ts
+++ b/client/src/components/templates/quote/types.ts
@@ -20,6 +20,7 @@ export interface QuoteModification {
   quote_line_item_id: number;
   description: string;
   price: string;
+  quantity: number;
   position: number;
 }
 

--- a/client/src/components/ui/CurrencyInput.tsx
+++ b/client/src/components/ui/CurrencyInput.tsx
@@ -17,25 +17,33 @@ const toText = (v: string | number | null | undefined): string =>
   v == null || v === '' ? '' : String(v);
 
 // Keep only digits and a single decimal point.
+// Keep only digits and a single decimal point, plus an optional leading
+// minus — negative prices are allowed (e.g. a discount / credit line).
+// The minus is preserved even before any digit is typed, so "-" → "-5".
 const sanitize = (raw: string): string => {
+  const neg = /^\s*-/.test(raw);
   const cleaned = raw.replace(/[^0-9.]/g, '');
   const firstDot = cleaned.indexOf('.');
-  if (firstDot === -1) return cleaned;
-  return (
-    cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '')
-  );
+  const digits =
+    firstDot === -1
+      ? cleaned
+      : cleaned.slice(0, firstDot + 1) +
+        cleaned.slice(firstDot + 1).replace(/\./g, '');
+  return (neg ? '-' : '') + digits;
 };
 
 // 2-dp banker's rounding (HALF_EVEN), returned as a fixed-2 string.
+// Sign-aware: round the magnitude then reapply the sign, never "-0.00".
 const toHalfEven2 = (n: number): string => {
-  const scaled = n * 100;
+  const scaled = Math.abs(n) * 100;
   const floor = Math.floor(scaled);
   const diff = scaled - floor;
   let rounded: number;
   if (diff > 0.5) rounded = floor + 1;
   else if (diff < 0.5) rounded = floor;
   else rounded = floor % 2 === 0 ? floor : floor + 1; // exactly .5 → to even
-  return (rounded / 100).toFixed(2);
+  const sign = n < 0 && rounded !== 0 ? -1 : 1;
+  return ((sign * rounded) / 100).toFixed(2);
 };
 
 // Strip leading zeros ("025.50" → "25.50", "0.5" stays) + clamp to 2dp.

--- a/client/src/routes/CreateInvoice.tsx
+++ b/client/src/routes/CreateInvoice.tsx
@@ -7,7 +7,6 @@ import {
   CurrencyInput,
   Flow,
   FlowStep,
-  IconButton,
   Stepper,
 } from '../components/ui';
 import { AddClientModal } from '../components/forms/AddClientModal';
@@ -21,11 +20,7 @@ import type {
   InvoiceLineContainer,
   InvoiceModification,
 } from '../components/templates/invoice/types';
-import {
-  MODIFICATION_DATALIST_ID,
-  useModPresetLabels,
-  useModPresets,
-} from '../components/forms/modificationPresets';
+import { ModificationRows } from '../components/forms/ModificationRows';
 import styles from './CreateInvoice.module.css';
 
 interface InventoryRow {
@@ -68,7 +63,12 @@ interface ContainerDraft {
   delivery_city: string;
   delivery_state: string;
   delivery_zip: string;
-  modifications: Array<{ id: number; description: string; price: string }>;
+  modifications: Array<{
+    id: number;
+    description: string;
+    price: string;
+    quantity: number;
+  }>;
 }
 
 interface TruckingCompany {
@@ -169,8 +169,6 @@ export default function CreateInvoice() {
   const [truckingCompanies, setTruckingCompanies] = useState<TruckingCompany[]>(
     [],
   );
-  const modPresetLabels = useModPresetLabels();
-  const modPresets = useModPresets();
   const [submitState, setSubmitState] = useState<
     | { kind: 'idle' }
     | { kind: 'submitting' }
@@ -385,7 +383,10 @@ export default function CreateInvoice() {
       if (!d) continue;
       subtotal += Number(d.sale_price || 0);
       subtotal += Number(d.trucking_rate || 0);
-      subtotal += d.modifications.reduce((s, m) => s + Number(m.price || 0), 0);
+      subtotal += d.modifications.reduce(
+        (s, m) => s + Number(m.price || 0) * (m.quantity || 1),
+        0,
+      );
     }
     const tax = invoiceTaxed ? subtotal * Number(taxRate || 0) : 0;
     const cc = invoiceCredit ? (subtotal + tax) * Number(ccFeeRate || 0) : 0;
@@ -402,6 +403,7 @@ export default function CreateInvoice() {
           sold_id: -1,
           description: m.description,
           price: m.price || '0',
+          quantity: m.quantity || 1,
           position: i,
         }),
       );
@@ -502,66 +504,19 @@ export default function CreateInvoice() {
     setDrafts((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
   };
 
-  const addMod = (id: number) => {
+  const setMods = (id: number, mods: ContainerDraft['modifications']) =>
     setDrafts((prev) => {
       const d = prev[id];
       if (!d) return prev;
-      return {
-        ...prev,
-        [id]: {
-          ...d,
-          modifications: [
-            ...d.modifications,
-            { id: -Date.now() - d.modifications.length, description: '', price: '0' },
-          ],
-        },
-      };
-    });
-  };
-
-  const updateMod = (
-    id: number,
-    modIdx: number,
-    patch: Partial<{ description: string; price: string }>,
-  ) => {
-    setDrafts((prev) => {
-      const d = prev[id];
-      if (!d) return prev;
-      const mods = d.modifications.slice();
-      const next = { ...mods[modIdx], ...patch };
-      // Autofill the price when the description matches a preset and
-      // the price field is empty / 0 — a typed value wins.
-      if (patch.description !== undefined) {
-        const match = modPresets.find(
-          (p) => p.label === patch.description?.trim(),
-        );
-        const currentPrice = Number(next.price);
-        const priceEmpty =
-          next.price === '' ||
-          next.price == null ||
-          (Number.isFinite(currentPrice) && currentPrice === 0);
-        if (match && match.default_price != null && priceEmpty) {
-          next.price = String(match.default_price);
-        }
-      }
-      mods[modIdx] = next;
       return { ...prev, [id]: { ...d, modifications: mods } };
     });
-  };
 
-  const removeMod = (id: number, modIdx: number) => {
-    setDrafts((prev) => {
-      const d = prev[id];
-      if (!d) return prev;
-      return {
-        ...prev,
-        [id]: {
-          ...d,
-          modifications: d.modifications.filter((_, i) => i !== modIdx),
-        },
-      };
-    });
-  };
+  const blankMod = (existing: number) => ({
+    id: -Date.now() - existing,
+    description: '',
+    price: '0',
+    quantity: 1,
+  });
 
   const canAdvance = () => {
     if (step === 0) return selectedIds.length > 0;
@@ -665,6 +620,7 @@ export default function CreateInvoice() {
                 .map((m, i) => ({
                   description: m.description,
                   price: m.price || '0',
+                  quantity: m.quantity || 1,
                   position: i,
                 })),
             };
@@ -900,12 +856,6 @@ export default function CreateInvoice() {
                 </label>
               </div>
             </div>
-            <datalist id={MODIFICATION_DATALIST_ID}>
-              {modPresetLabels.map((d) => (
-                <option key={d} value={d} />
-              ))}
-            </datalist>
-
             <div className={styles.containerCard}>
               <div className={styles.containerHead}>
                 <strong>Shipping address</strong>
@@ -1055,37 +1005,11 @@ export default function CreateInvoice() {
                     <div className={styles.modsHeader}>
                       <span className={styles.fieldLabel}>Modifications</span>
                     </div>
-                    {d.modifications.map((m, mIdx) => (
-                      <div key={m.id} className={styles.modRow}>
-                        <input
-                          className={styles.input}
-                          list={MODIFICATION_DATALIST_ID}
-                          placeholder="Description (or pick a preset)"
-                          value={m.description}
-                          onChange={(e) =>
-                            updateMod(id, mIdx, { description: e.target.value })
-                          }
-                        />
-                        <CurrencyInput
-                          value={m.price}
-                          onChange={(v) => updateMod(id, mIdx, { price: v })}
-                          placeholder="0.00"
-                        />
-                        <IconButton
-                          icon="trash"
-                          tone="danger"
-                          label="Remove modification"
-                          onClick={() => removeMod(id, mIdx)}
-                        />
-                      </div>
-                    ))}
-                    <button
-                      type="button"
-                      className={styles.addRow}
-                      onClick={() => addMod(id)}
-                    >
-                      + Add modification
-                    </button>
+                    <ModificationRows
+                      mods={d.modifications}
+                      onChange={(next) => setMods(id, next)}
+                      makeBlank={() => blankMod(d.modifications.length)}
+                    />
                   </div>
                 </div>
               );

--- a/client/src/routes/CreateQuote.tsx
+++ b/client/src/routes/CreateQuote.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import {
   Badge,
   Button,
-  CurrencyInput,
   Flow,
   FlowStep,
   IconButton,
@@ -20,11 +19,7 @@ import type {
   QuoteLine,
   QuoteModification,
 } from '../components/templates/quote/types';
-import {
-  MODIFICATION_DATALIST_ID,
-  useModPresetLabels,
-  useModPresets,
-} from '../components/forms/modificationPresets';
+import { ModificationRows } from '../components/forms/ModificationRows';
 import styles from './CreateQuote.module.css';
 
 interface ClientRow {
@@ -46,7 +41,12 @@ interface LineDraft {
   sale_price: string;
   trucking_rate: string;
   destination: string;
-  modifications: Array<{ id: number; description: string; price: string }>;
+  modifications: Array<{
+    id: number;
+    description: string;
+    price: string;
+    quantity: number;
+  }>;
 }
 
 const STEP_NAMES = ['Customer', 'Lines', 'Details', 'Preview', 'Done'] as const;
@@ -100,8 +100,6 @@ export default function CreateQuote() {
   const [taxRate, setTaxRate] = useState('0.06625');
   const [ccFeePct, setCcFeePct] = useState('3.5');
   const ccFeeRate = pctToDecimal(ccFeePct);
-  const modPresetLabels = useModPresetLabels();
-  const modPresets = useModPresets();
   const [submitState, setSubmitState] = useState<
     | { kind: 'idle' }
     | { kind: 'submitting' }
@@ -214,7 +212,10 @@ export default function CreateQuote() {
     for (const l of lines) {
       subtotal += Number(l.sale_price || 0);
       subtotal += Number(l.trucking_rate || 0);
-      subtotal += l.modifications.reduce((s, m) => s + Number(m.price || 0), 0);
+      subtotal += l.modifications.reduce(
+        (s, m) => s + Number(m.price || 0) * (m.quantity || 1),
+        0,
+      );
     }
     const tax = quoteTaxed ? subtotal * Number(taxRate || 0) : 0;
     const cc = quoteCredit ? (subtotal + tax) * Number(ccFeeRate || 0) : 0;
@@ -231,6 +232,7 @@ export default function CreateQuote() {
           quote_line_item_id: -1,
           description: m.description,
           price: m.price || '0',
+          quantity: m.quantity || 1,
           position: j,
         }));
         return {
@@ -312,67 +314,12 @@ export default function CreateQuote() {
   const removeLine = (key: number) =>
     setLines((prev) => prev.filter((l) => l.key !== key));
 
-  const addMod = (key: number) => {
-    setLines((prev) =>
-      prev.map((l) =>
-        l.key === key
-          ? {
-              ...l,
-              modifications: [
-                ...l.modifications,
-                {
-                  id: -Date.now() - l.modifications.length,
-                  description: '',
-                  price: '0',
-                },
-              ],
-            }
-          : l,
-      ),
-    );
-  };
-
-  const updateMod = (
-    key: number,
-    modIdx: number,
-    patch: Partial<{ description: string; price: string }>,
-  ) => {
-    setLines((prev) =>
-      prev.map((l) => {
-        if (l.key !== key) return l;
-        const mods = l.modifications.slice();
-        const next = { ...mods[modIdx], ...patch };
-        if (patch.description !== undefined) {
-          const match = modPresets.find(
-            (p) => p.label === patch.description?.trim(),
-          );
-          const currentPrice = Number(next.price);
-          const priceEmpty =
-            next.price === '' ||
-            next.price == null ||
-            (Number.isFinite(currentPrice) && currentPrice === 0);
-          if (match && match.default_price != null && priceEmpty) {
-            next.price = String(match.default_price);
-          }
-        }
-        mods[modIdx] = next;
-        return { ...l, modifications: mods };
-      }),
-    );
-  };
-
-  const removeMod = (key: number, modIdx: number) => {
-    setLines((prev) =>
-      prev.map((l) =>
-        l.key === key
-          ? {
-              ...l,
-              modifications: l.modifications.filter((_, i) => i !== modIdx),
-            }
-          : l,
-      ),
-    );
-  };
+  const blankMod = (existing: number) => ({
+    id: -Date.now() - existing,
+    description: '',
+    price: '0',
+    quantity: 1,
+  });
 
   const validLines = lines.filter((l) => l.description.trim() !== '');
 
@@ -417,6 +364,7 @@ export default function CreateQuote() {
               .map((m, j) => ({
                 description: m.description,
                 price: m.price || '0',
+                quantity: m.quantity || 1,
                 position: j,
               })),
           })),
@@ -531,12 +479,6 @@ export default function CreateQuote() {
               a price — there are no containers on a quote. Sale price is
               required on every line.
             </p>
-            <datalist id={MODIFICATION_DATALIST_ID}>
-              {modPresetLabels.map((d) => (
-                <option key={d} value={d} />
-              ))}
-            </datalist>
-
             {lines.map((l) => (
               <div key={l.key} className={styles.containerCard}>
                 <div className={styles.containerHead}>
@@ -598,44 +540,13 @@ export default function CreateQuote() {
                   <div className={styles.modsHeader}>
                     <span className={styles.fieldLabel}>Modifications</span>
                   </div>
-                  {l.modifications.length === 0 && (
-                    <p className={styles.modsEmpty}>
-                      No modifications yet.
-                    </p>
-                  )}
-                  {l.modifications.map((m, mIdx) => (
-                    <div key={m.id} className={styles.modRow}>
-                      <input
-                        className={styles.input}
-                        list={MODIFICATION_DATALIST_ID}
-                        placeholder="Description (or pick a preset)"
-                        value={m.description}
-                        onChange={(e) =>
-                          updateMod(l.key, mIdx, { description: e.target.value })
-                        }
-                      />
-                      <CurrencyInput
-                        value={m.price}
-                        onChange={(v) =>
-                          updateMod(l.key, mIdx, { price: v })
-                        }
-                        placeholder="0.00"
-                      />
-                      <IconButton
-                        icon="trash"
-                        tone="danger"
-                        label="Remove modification"
-                        onClick={() => removeMod(l.key, mIdx)}
-                      />
-                    </div>
-                  ))}
-                  <button
-                    type="button"
-                    className={styles.addRow}
-                    onClick={() => addMod(l.key)}
-                  >
-                    + Add modification
-                  </button>
+                  <ModificationRows
+                    mods={l.modifications}
+                    onChange={(next) =>
+                      updateLine(l.key, { modifications: next })
+                    }
+                    makeBlank={() => blankMod(l.modifications.length)}
+                  />
                 </div>
               </div>
             ))}

--- a/client/src/routes/QuoteDetail.tsx
+++ b/client/src/routes/QuoteDetail.tsx
@@ -271,6 +271,7 @@ export default function QuoteDetail() {
                 .map((m, j) => ({
                   description: m.description,
                   price: m.price,
+                  quantity: m.quantity ?? 1,
                   position: j,
                 })),
             })),
@@ -523,6 +524,7 @@ export default function QuoteDetail() {
           sold_id: -1,
           description: m.description,
           price: m.price ?? '0',
+          quantity: m.quantity ?? 1,
           position: mi,
         })),
       };
@@ -531,7 +533,10 @@ export default function QuoteDetail() {
     for (const c of containers) {
       subtotal += Number(c.sale_price ?? 0);
       subtotal += Number(c.trucking_rate ?? 0);
-      subtotal += c.modifications.reduce((s, m) => s + Number(m.price ?? 0), 0);
+      subtotal += c.modifications.reduce(
+        (s, m) => s + Number(m.price ?? 0) * (m.quantity || 1),
+        0,
+      );
     }
     const taxAmount = quote.quote_taxed ? subtotal * taxRate : 0;
     const ccAmount = quote.quote_credit ? (subtotal + taxAmount) * ccRate : 0;

--- a/client/src/routes/QuoteDetail.tsx
+++ b/client/src/routes/QuoteDetail.tsx
@@ -179,6 +179,35 @@ export default function QuoteDetail() {
     }
   };
 
+  const handleDownloadPdf = async () => {
+    if (!quote) return;
+    setAction({ kind: 'busy', label: 'Generating PDF…' });
+    try {
+      const res = await fetch(`/api/v2/quote/${quote.id}/pdf`, {
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message ?? `Something went wrong`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `quote-${quote.quote_number}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setAction({ kind: 'ok', message: 'PDF downloaded.' });
+    } catch (e) {
+      setAction({
+        kind: 'err',
+        message: e instanceof Error ? e.message : 'Download failed',
+      });
+    }
+  };
+
   const handleEmail = async () => {
     if (!quote) return;
     const fallbackTo = quote.customer.contact_email ?? '';
@@ -646,6 +675,11 @@ export default function QuoteDetail() {
             {isAdmin && (
               <Button variant="secondary" onClick={() => setEditing(true)}>
                 Edit
+              </Button>
+            )}
+            {isAdmin && (
+              <Button variant="secondary" onClick={handleDownloadPdf}>
+                Download PDF
               </Button>
             )}
             {isAdmin && (

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -6,39 +6,28 @@
 
 ## TL;DR
 
-**Shipped & live.** PR #12 and PR #13 are merged and deployed; cutover ran and **prod is on migrations 0022/0023** (confirmed live 2026-06-06 via `server/scripts/prod-diagnose.sh`).
+**2.0 + structural batch ready to ship.** PR [#12](https://github.com/harrylynchh/airtight-container/pull/12) (`phase-struct/structural-batch` → `main`) carries 61 commits: delivery epic, Quote domain, Outbound stepper, promote-to-invoice rework, address picker, S&H domain expansion (billing modes + release linkage), polish pass (Toast bridge, masked inputs, CurrencyInput sweep, Stepper bg fix), P&L `deleted_at` filter. **Tests: client 50/50, server 211/211, tsc clean both sides.**
 
-**Post-ship bug week (2026-06-06).** Three operator-reported issues triaged:
+**Prod DB is already audited + restored** as of 2026-05-29:
+- `containers_2.0_POST-AUDIT_20260529_140725.psql` restored to `containers_prod` on EC2.
+- Audit verifier `POST_RESTORE_VERIFY.sql` reports **39/39 PASS** on prod.
+- Migrations 0016 → 0021 baked into the dump; no manual `psql -f` needed on prod.
+- Pre-audit + pre-restore dumps both archived in `~/airtight-cutover/` on EC2 (rollback artifacts).
 
-1. **Quote promote 500'd** — `relation "quote_lines" does not exist` (typo for `quote_line_items` in `routes/v2/quote.js`). **Fixed → PR #14 merged → deploy green, operator unblocked.**
-2. **Quotes "not reaching the work email"** — *not a bug.* Sending is healthy (customers + Gmail BCC receive). Root cause: Proofpoint same-domain anti-spoof on `airtightstorage.com` quarantines mail that's `From: @airtightstorage.com` but relayed via Resend, so the self-addressed copy never lands. **Deferred by owner.** Full writeup in auto-memory `quote_email_proofpoint_diagnosis.md`.
-3. **Outage remediation (2026-06-04 OOM hard-lock).** **PR [#15](https://github.com/harrylynchh/airtight-container/pull/15) OPEN — next step is review + merge.** Consolidates the 3 separate Puppeteer browsers into one shared instance (`server/lib/puppeteer.ts`) with a render-count/age recycle, drops `--single-process` (verified it hangs `page.pdf()`), and adds `mem_limit: 600m` to the backend in `docker-compose.yml`. Swap (2 GB) is already live on EC2. Also folds in a fix for the date-relative `sh-checkout.test.ts` flake (fixture `intake_date` was `now()`-relative against hardcoded 2026 windows; now pinned to `2026-04-01`).
-
-**Feature batch (2026-06-06), 3 more PRs open** (plan in `~/.claude/plans/indexed-growing-neumann.md`):
-
-4. **PR [#16](https://github.com/harrylynchh/airtight-container/pull/16) — quick wins** (`feat/quote-invoice-quickwins` → `main`, ready): $0 sale price allowed in both create steppers; quote "+ Add line item" copies the line above; localStorage draft autosave (`useDraftPersistence`) on quote+invoice create with auto-restore + "Discard draft". No migration. client 50/50, tsc clean.
-5. **PR [#17](https://github.com/harrylynchh/airtight-container/pull/17) — mod dropdown + quantity** (`feat/mod-rows-quantity`, **DRAFT, stacked on #16**). Shared `ModificationRows.tsx` (real `<select>` + "Custom" write-in, replaces iPad-hostile datalist, fixes preset price-rebind). Per-modification **quantity** ("4× windows"): migration **0024** + schema/validation/ops/PDF. **HOLD: owner reviewing the qty render (screenshots sent); apply `0024` to prod only after sign-off.**
-6. **PR [#18](https://github.com/harrylynchh/airtight-container/pull/18) — multi-page invoices** (`feat/invoice-pagination`, **DRAFT, stacked on #15**). Page top/bottom margins + "Page X / N" footer; short invoices no longer forced to 2 pages. Invoice-render-path only.
-
-**Tests:** server 226/226 (on #15's branch), client 50/50, tsc clean throughout.
+**Stack is `docker compose down` on prod.** Merging PR #12 fires the GHA deploy workflow → builds new images → SSHes to EC2 → `docker compose up -d` against the audited DB. **Add the GH secret `VITE_GOOGLE_MAPS_API_KEY` first** if you want the address picker live (absent = picker hidden, no crash).
 
 ---
 
-## Next concrete step
+## Post-deploy spot-checks
 
-**Merge order matters** (two stacks):
-
-1. **PR #15** (outage) → then **PR #18** retargets `main` & merges (pagination). Post-#15 checks:
-
-| Check | Expected |
+| Surface | Expected |
 | --- | --- |
-| `docker inspect airtight-container-backend-1 --format '{{.HostConfig.Memory}}'` | `629145600` (600 MB) |
-| `docker stats …` (~30 min) | RSS plateaus | 
-| `docker exec … ps -ef \| grep chromium` after a few PDFs | one browser, recycles after 50/6h |
+| `/inventory` | 55 available · S&H tabs visible (empty until you intake) |
+| `/releases` | `AUDIT-5-29-26` with 8/50 used |
+| `/dashboard` | Active total = $656,924.05 (tombstones excluded) |
+| Auth | Sign-in works (Better Auth tables came over in the dump) |
 
-2. **PR #16** (quick wins) → then, after owner signs off on the qty render, **PR #17**: apply `server/db/migrations/0024_modification_quantity.sql` to `containers_prod` (additive, safe), retarget #17 to `main`, merge. (`0024` already applied to **local** DB.)
-
-**Deferred:** quote-email Proofpoint config (owner); t3.small instance bump (~1 wk observation).
+If anything looks off, run `POST_RESTORE_VERIFY.sql` again — should still be 39/39.
 
 ---
 
@@ -101,7 +90,7 @@ Full spec + step ordering: [docs/AUDIT_MIGRATION.md](AUDIT_MIGRATION.md).
 ## Conventions
 
 - `main` deploys on push.
-- Migrations stay numbered + applied manually (`psql -f`); drizzle-kit not at runtime. **Prod is at `0023`.**
+- Migrations stay numbered + applied manually (`psql -f`); drizzle-kit not at runtime. Prod is at `0021` (baked into the audited dump).
 - `userContext.jsx` is the global user/popup/theme context (popup state now bridges to the Toast viewport — every existing `setPopup` call still works).
 - Deploy build runs `tsc --noEmit && vite build` inside `Dockerfile.frontend` — any tsc error breaks deploy. `App.jsx` is `.jsx` so it's not type-checked; eyeball on back-merge.
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -6,28 +6,39 @@
 
 ## TL;DR
 
-**2.0 + structural batch ready to ship.** PR [#12](https://github.com/harrylynchh/airtight-container/pull/12) (`phase-struct/structural-batch` → `main`) carries 61 commits: delivery epic, Quote domain, Outbound stepper, promote-to-invoice rework, address picker, S&H domain expansion (billing modes + release linkage), polish pass (Toast bridge, masked inputs, CurrencyInput sweep, Stepper bg fix), P&L `deleted_at` filter. **Tests: client 50/50, server 211/211, tsc clean both sides.**
+**Shipped & live.** PR #12 and PR #13 are merged and deployed; cutover ran and **prod is on migrations 0022/0023** (confirmed live 2026-06-06 via `server/scripts/prod-diagnose.sh`).
 
-**Prod DB is already audited + restored** as of 2026-05-29:
-- `containers_2.0_POST-AUDIT_20260529_140725.psql` restored to `containers_prod` on EC2.
-- Audit verifier `POST_RESTORE_VERIFY.sql` reports **39/39 PASS** on prod.
-- Migrations 0016 → 0021 baked into the dump; no manual `psql -f` needed on prod.
-- Pre-audit + pre-restore dumps both archived in `~/airtight-cutover/` on EC2 (rollback artifacts).
+**Post-ship bug week (2026-06-06).** Three operator-reported issues triaged:
 
-**Stack is `docker compose down` on prod.** Merging PR #12 fires the GHA deploy workflow → builds new images → SSHes to EC2 → `docker compose up -d` against the audited DB. **Add the GH secret `VITE_GOOGLE_MAPS_API_KEY` first** if you want the address picker live (absent = picker hidden, no crash).
+1. **Quote promote 500'd** — `relation "quote_lines" does not exist` (typo for `quote_line_items` in `routes/v2/quote.js`). **Fixed → PR #14 merged → deploy green, operator unblocked.**
+2. **Quotes "not reaching the work email"** — *not a bug.* Sending is healthy (customers + Gmail BCC receive). Root cause: Proofpoint same-domain anti-spoof on `airtightstorage.com` quarantines mail that's `From: @airtightstorage.com` but relayed via Resend, so the self-addressed copy never lands. **Deferred by owner.** Full writeup in auto-memory `quote_email_proofpoint_diagnosis.md`.
+3. **Outage remediation (2026-06-04 OOM hard-lock).** **PR [#15](https://github.com/harrylynchh/airtight-container/pull/15) OPEN — next step is review + merge.** Consolidates the 3 separate Puppeteer browsers into one shared instance (`server/lib/puppeteer.ts`) with a render-count/age recycle, drops `--single-process` (verified it hangs `page.pdf()`), and adds `mem_limit: 600m` to the backend in `docker-compose.yml`. Swap (2 GB) is already live on EC2. Also folds in a fix for the date-relative `sh-checkout.test.ts` flake (fixture `intake_date` was `now()`-relative against hardcoded 2026 windows; now pinned to `2026-04-01`).
+
+**Feature batch (2026-06-06), 3 more PRs open** (plan in `~/.claude/plans/indexed-growing-neumann.md`):
+
+4. **PR [#16](https://github.com/harrylynchh/airtight-container/pull/16) — quick wins** (`feat/quote-invoice-quickwins` → `main`, ready): $0 sale price allowed in both create steppers; quote "+ Add line item" copies the line above; localStorage draft autosave (`useDraftPersistence`) on quote+invoice create with auto-restore + "Discard draft". No migration. client 50/50, tsc clean.
+5. **PR [#17](https://github.com/harrylynchh/airtight-container/pull/17) — mod dropdown + quantity** (`feat/mod-rows-quantity`, **DRAFT, stacked on #16**). Shared `ModificationRows.tsx` (real `<select>` + "Custom" write-in, replaces iPad-hostile datalist, fixes preset price-rebind). Per-modification **quantity** ("4× windows"): migration **0024** + schema/validation/ops/PDF. **HOLD: owner reviewing the qty render (screenshots sent); apply `0024` to prod only after sign-off.**
+6. **PR [#18](https://github.com/harrylynchh/airtight-container/pull/18) — multi-page invoices** (`feat/invoice-pagination`, **DRAFT, stacked on #15**). Page top/bottom margins + "Page X / N" footer; short invoices no longer forced to 2 pages. Invoice-render-path only.
+
+**Tests:** server 226/226 (on #15's branch), client 50/50, tsc clean throughout.
 
 ---
 
-## Post-deploy spot-checks
+## Next concrete step
 
-| Surface | Expected |
+**Merge order matters** (two stacks):
+
+1. **PR #15** (outage) → then **PR #18** retargets `main` & merges (pagination). Post-#15 checks:
+
+| Check | Expected |
 | --- | --- |
-| `/inventory` | 55 available · S&H tabs visible (empty until you intake) |
-| `/releases` | `AUDIT-5-29-26` with 8/50 used |
-| `/dashboard` | Active total = $656,924.05 (tombstones excluded) |
-| Auth | Sign-in works (Better Auth tables came over in the dump) |
+| `docker inspect airtight-container-backend-1 --format '{{.HostConfig.Memory}}'` | `629145600` (600 MB) |
+| `docker stats …` (~30 min) | RSS plateaus | 
+| `docker exec … ps -ef \| grep chromium` after a few PDFs | one browser, recycles after 50/6h |
 
-If anything looks off, run `POST_RESTORE_VERIFY.sql` again — should still be 39/39.
+2. **PR #16** (quick wins) → then, after owner signs off on the qty render, **PR #17**: apply `server/db/migrations/0024_modification_quantity.sql` to `containers_prod` (additive, safe), retarget #17 to `main`, merge. (`0024` already applied to **local** DB.)
+
+**Deferred:** quote-email Proofpoint config (owner); t3.small instance bump (~1 wk observation).
 
 ---
 
@@ -90,7 +101,7 @@ Full spec + step ordering: [docs/AUDIT_MIGRATION.md](AUDIT_MIGRATION.md).
 ## Conventions
 
 - `main` deploys on push.
-- Migrations stay numbered + applied manually (`psql -f`); drizzle-kit not at runtime. Prod is at `0021` (baked into the audited dump).
+- Migrations stay numbered + applied manually (`psql -f`); drizzle-kit not at runtime. **Prod is at `0023`.**
 - `userContext.jsx` is the global user/popup/theme context (popup state now bridges to the Toast viewport — every existing `setPopup` call still works).
 - Deploy build runs `tsc --noEmit && vite build` inside `Dockerfile.frontend` — any tsc error breaks deploy. `App.jsx` is `.jsx` so it's not type-checked; eyeball on back-merge.
 

--- a/server/db/migrations/0024_modification_quantity.sql
+++ b/server/db/migrations/0024_modification_quantity.sql
@@ -1,0 +1,10 @@
+-- Quantity on modification line items (2026-06-06). "4x windows" etc.
+-- Both modification tables get a quantity that multiplies the unit price
+-- into the line total. Default 1 so every existing row keeps its current
+-- (price x 1) behavior. Additive + idempotent.
+
+ALTER TABLE quote_line_modifications
+  ADD COLUMN IF NOT EXISTS quantity integer NOT NULL DEFAULT 1;
+
+ALTER TABLE sold_modifications
+  ADD COLUMN IF NOT EXISTS quantity integer NOT NULL DEFAULT 1;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -216,6 +216,7 @@ export const sold_modifications = pgTable(
       .references(() => sold.id, { onDelete: 'cascade' }),
     description: text('description').notNull(),
     price: numeric('price').notNull(),
+    quantity: integer('quantity').notNull().default(1),
     position: integer('position').notNull().default(0),
   },
   (table) => ({
@@ -558,6 +559,7 @@ export const quote_line_modifications = pgTable(
       .references(() => quote_line_items.id, { onDelete: 'cascade' }),
     description: text('description').notNull(),
     price: numeric('price').notNull(),
+    quantity: integer('quantity').notNull().default(1),
     position: integer('position').notNull().default(0),
   },
   (table) => ({

--- a/server/lib/invoice-ops.ts
+++ b/server/lib/invoice-ops.ts
@@ -16,6 +16,7 @@ const SALES_INVOICE_SEQ_LOCK_KEY = 0x4149_5253_4551_4e23n.toString();
 export interface IncomingModification {
   description?: string;
   price?: string | number | null;
+  quantity?: number | null;
   position?: number | null;
 }
 
@@ -129,12 +130,16 @@ export async function recomputeTotals(
     const { rows: modRows } = await client.query<{
       sold_id: number;
       price: string;
+      quantity: number;
     }>(
-      `SELECT sold_id, price FROM sold_modifications WHERE sold_id = ANY($1::int[])`,
+      `SELECT sold_id, price, quantity FROM sold_modifications WHERE sold_id = ANY($1::int[])`,
       [soldIds],
     );
     for (const m of modRows) {
-      modsBySold.set(m.sold_id, (modsBySold.get(m.sold_id) ?? 0) + Number(m.price));
+      modsBySold.set(
+        m.sold_id,
+        (modsBySold.get(m.sold_id) ?? 0) + Number(m.price) * (m.quantity || 1),
+      );
     }
   }
   let subtotal = 0;
@@ -355,8 +360,8 @@ export async function updateInvoiceFull(
         const m = mods[i];
         if (!m.description || m.price == null) continue;
         await client.query(
-          'INSERT INTO sold_modifications (sold_id, description, price, position) VALUES ($1, $2, $3, $4)',
-          [soldId, m.description, m.price, m.position ?? i],
+          'INSERT INTO sold_modifications (sold_id, description, price, quantity, position) VALUES ($1, $2, $3, $4, $5)',
+          [soldId, m.description, m.price, m.quantity ?? 1, m.position ?? i],
         );
       }
     }

--- a/server/lib/pdf.ts
+++ b/server/lib/pdf.ts
@@ -145,6 +145,7 @@ interface InvoiceModification {
   sold_id: number;
   description: string;
   price: string;
+  quantity: number;
   position: number;
 }
 
@@ -212,7 +213,7 @@ async function fetchInvoiceData(invoiceId: number): Promise<InvoiceData | null> 
     .filter((id): id is number => id != null);
   if (soldIds.length > 0) {
     const modResult = await db.query(
-      `SELECT id, sold_id, description, price, position
+      `SELECT id, sold_id, description, price, quantity, position
        FROM sold_modifications
        WHERE sold_id = ANY($1::int[])
        ORDER BY sold_id, position, id`,

--- a/server/lib/quote-ops.ts
+++ b/server/lib/quote-ops.ts
@@ -16,6 +16,7 @@ import type { IncomingContainer, IncomingModification } from './invoice-ops.js';
 export interface IncomingQuoteMod {
   description?: string;
   price?: string | number | null;
+  quantity?: number | null;
   position?: number | null;
 }
 
@@ -77,8 +78,9 @@ export async function recomputeQuoteTotals(
     const { rows: modRows } = await client.query<{
       quote_line_item_id: number;
       price: string;
+      quantity: number;
     }>(
-      `SELECT quote_line_item_id, price
+      `SELECT quote_line_item_id, price, quantity
          FROM quote_line_modifications
         WHERE quote_line_item_id = ANY($1::int[])`,
       [lineIds],
@@ -86,7 +88,8 @@ export async function recomputeQuoteTotals(
     for (const m of modRows) {
       modsByLine.set(
         m.quote_line_item_id,
-        (modsByLine.get(m.quote_line_item_id) ?? 0) + Number(m.price),
+        (modsByLine.get(m.quote_line_item_id) ?? 0) +
+          Number(m.price) * (m.quantity || 1),
       );
     }
   }
@@ -163,9 +166,9 @@ async function replaceLines(
       if (!m.description || m.price == null) continue;
       await client.query(
         `INSERT INTO quote_line_modifications
-           (quote_line_item_id, description, price, position)
-         VALUES ($1, $2, $3, $4)`,
-        [lineId, m.description, m.price, m.position ?? j],
+           (quote_line_item_id, description, price, quantity, position)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [lineId, m.description, m.price, m.quantity ?? 1, m.position ?? j],
       );
     }
   }
@@ -359,9 +362,10 @@ export async function promoteQuoteToInvoice(
     quote_line_item_id: number;
     description: string;
     price: string;
+    quantity: number;
     position: number;
   }>(
-    `SELECT quote_line_item_id, description, price, position
+    `SELECT quote_line_item_id, description, price, quantity, position
        FROM quote_line_modifications
       WHERE quote_line_item_id = ANY($1::int[])
       ORDER BY quote_line_item_id, position, id`,
@@ -374,6 +378,7 @@ export async function promoteQuoteToInvoice(
     modsByLine.get(m.quote_line_item_id)!.push({
       description: m.description,
       price: m.price,
+      quantity: m.quantity,
       position: m.position,
     });
   }

--- a/server/lib/quote-pdf.ts
+++ b/server/lib/quote-pdf.ts
@@ -98,6 +98,7 @@ interface QuoteData {
       id: number;
       description: string;
       price: string;
+      quantity: number;
       position: number;
     }>;
   }>;
@@ -133,7 +134,7 @@ export async function fetchQuoteData(quoteId: number): Promise<QuoteData | null>
   const modsByLine = new Map<number, any[]>();
   if (lineIds.length > 0) {
     const { rows: modRows } = await db.query(
-      `SELECT id, quote_line_item_id, description, price, position
+      `SELECT id, quote_line_item_id, description, price, quantity, position
          FROM quote_line_modifications
         WHERE quote_line_item_id = ANY($1::int[])
         ORDER BY quote_line_item_id, position, id`,

--- a/server/routes/v2/quote.js
+++ b/server/routes/v2/quote.js
@@ -262,6 +262,43 @@ router.post("/:id/pdf", checkAdmin, async (req, res) => {
 	}
 });
 
+// Re-render fresh, refresh the cached S3 object, then stream the PDF back
+// as an attachment. No email is sent. Mirrors invoice GET /:id/pdf.
+router.get("/:id/pdf", checkAdmin, async (req, res) => {
+	const id = parseInt(req.params.id, 10);
+	if (!Number.isFinite(id)) {
+		return res.status(400).json({ message: "Invalid quote id" });
+	}
+	try {
+		const { rows } = await db.query(
+			"SELECT quote_number, deleted_at FROM quotes WHERE id = $1",
+			[id],
+		);
+		const quote = rows[0];
+		if (!quote) return res.status(404).json({ message: "Not found" });
+		if (quote.deleted_at !== null) {
+			return res.status(409).json({ message: "Quote is deleted" });
+		}
+		const { s3Key } = await renderAndStoreQuotePdf(id);
+		await db.query("UPDATE quotes SET pdf_s3_key = $1 WHERE id = $2", [
+			s3Key,
+			id,
+		]);
+		const pdfBytes = await getQuotePdfBytes(s3Key);
+		res.status(200);
+		res.setHeader("Content-Type", "application/pdf");
+		res.setHeader(
+			"Content-Disposition",
+			`attachment; filename="quote-${quote.quote_number}.pdf"`,
+		);
+		res.setHeader("Content-Length", pdfBytes.length);
+		res.end(pdfBytes);
+	} catch (err) {
+		console.error("quote.pdf.download error:", err);
+		res.status(500).json({ message: err.message || "Internal server error" });
+	}
+});
+
 const SEND_BCC = (process.env.SEND_BCC ?? "")
 	.split(",")
 	.map((s) => s.trim())

--- a/server/validation/quote.ts
+++ b/server/validation/quote.ts
@@ -13,6 +13,7 @@ const moneyish = z
 const quoteModSchema = z.object({
   description: z.string().trim().max(500).optional(),
   price: moneyish,
+  quantity: z.number().int().min(1).default(1),
   position: z.number().int().optional().nullable(),
 });
 


### PR DESCRIPTION
> **Draft — pending owner sign-off on the quantity rendering, and the prod migration.** Stacked on #16; retarget to `main` once #16 merges.

## What

### Modification row overhaul — shared `ModificationRows.tsx` (all 4 editors)
Replaces four copies of the iPad-hostile `<datalist>` markup:
- Description is a real `<select>` of presets with an explicit **"Custom (write-in)"** default that reveals a free-text field.
- Picking **or changing** a preset always (re)binds its default price (fixes the bug where switching presets kept the old price).
- **Quantity is a dropdown (1–20)**, not a number spinner — the up/down arrows are fiddly on iPad, and a dropdown makes a negative quantity impossible.

### Per-modification quantity ("4× windows")
- Migration **`0024`** adds `quantity int NOT NULL DEFAULT 1` to `quote_line_modifications` + `sold_modifications`.
- `schema.ts`, validation, `quote-ops`/`invoice-ops` inserts + subtotal math (`price × quantity`), promote carries it, PDF fetchers select it. Both PDF templates' Qty column now shows the quantity + extended amount.

### Negative prices
- `CurrencyInput` now accepts a leading minus (discount / credit lines); rounding is sign-aware, never "-0.00". Server `moneyish` already allowed negatives.

### Quote "Download PDF" button
- New `GET /api/v2/quote/:id/pdf` re-renders fresh and streams the PDF as an attachment (mirrors the invoice download); a **Download PDF** button added to `QuoteDetail`.

## Testing
- client 50/50 (updated the InvoiceEditor mod-row test to the new markup), `tsc` clean both sides.
- Rendered quote + invoice with a `4× $25` mod → **Qty 4 · $25.00 · $100.00**, folded into the subtotal. (Screenshots shared with owner.)

## Deploy
- Apply `server/db/migrations/0024_modification_quantity.sql` to `containers_prod` (additive, safe) before/with merge. Docker rebuilds the PDF bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
