### PR TITLE
Feat: multi-page pagination for invoices + quotes (draft, stacked on #15)

### DIFF
--- a/server/lib/pdf-print.ts
+++ b/server/lib/pdf-print.ts
@@ -1,0 +1,72 @@
+// Shared print-pagination helpers for the customer-facing PDFs (invoice
+// + quote). Both are one tall `.sheet` div whose padding + min-height
+// only apply at the element edges, so without these a page 2 began flush
+// against the top of the paper and a short doc was still forced to a full
+// 11in. We let the Puppeteer page margins own the top/bottom whitespace
+// on EVERY page and neutralize the sheet's own vertical sizing.
+
+// `.sheet` is a hashed CSS-module class, so it's targeted structurally as
+// the sole body child. html/body get the cream background so the margin
+// bands are paper-colored too, not white. Rows don't split across a page
+// break; the table header repeats per page (Chromium default, explicit).
+// NB: the sheet is display:flex in screen CSS, but flex children can't
+// fragment across printed pages in Chromium — a long table would jump
+// wholesale to page 2 instead of splitting. Force block layout for print
+// so the table flows naturally. The footer (bottom-pinned via margin-top:
+// auto under flex) then just trails the content, which is the correct
+// multi-page behavior.
+export const PRINT_OVERRIDES = `
+html, body { background: #fdfcf8; margin: 0; }
+body > div:first-child {
+  display: block !important;
+  min-height: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+body > div:first-child > footer { margin-top: 0 !important; }
+table { page-break-inside: auto; }
+tr { page-break-inside: avoid; }
+thead { display: table-header-group; }
+/* The templates set break-after:avoid on every parent row to keep a line
+   attached to its modification/delivery sub-rows. For a line with NO subs
+   that chains into "never break after any row", making the whole table
+   atomic so it jumps wholesale to page 2. Re-allow a break after subless
+   rows (rows with subs still stay glued to their children). */
+tr[data-has-subs='false'] {
+  break-after: auto !important;
+  page-break-after: auto !important;
+}
+`;
+
+// Small right-aligned "Page X / N" footer. Puppeteer header/footer
+// templates render in an isolated context with font-size 0 by default, so
+// size/padding are set inline. The horizontal padding matches the sheet's
+// 0.85in side inset; the bottom page margin reserves room for it.
+export const FOOTER_TEMPLATE = `
+<div style="width:100%; font-size:8px; color:#5a6478; font-family: sans-serif; padding:0 0.85in; text-align:right;">
+  Page <span class="pageNumber"></span> / <span class="totalPages"></span>
+</div>`;
+
+export function wrapPrintHtml(ssrHtml: string, css: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style>${css}</style>
+<style>${PRINT_OVERRIDES}</style>
+</head>
+<body>${ssrHtml}</body>
+</html>`;
+}
+
+// page.pdf options that give every page (page 1 AND continuation pages)
+// top/bottom breathing room and a page-number footer. Left/right stay 0 —
+// the sheet owns its 0.85in horizontal inset.
+export const PAGINATED_PDF_OPTIONS = {
+  format: 'Letter' as const,
+  printBackground: true,
+  margin: { top: '0.55in', right: 0, bottom: '0.7in', left: 0 },
+  displayHeaderFooter: true,
+  headerTemplate: '<div></div>',
+  footerTemplate: FOOTER_TEMPLATE,
+};

--- a/server/lib/pdf.ts
+++ b/server/lib/pdf.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import db from '../db/index.js';
 import { putObject, getObjectBytes } from './s3.js';
+import { wrapPrintHtml, PAGINATED_PDF_OPTIONS } from './pdf-print.js';
 import { withPage, closeBrowser } from './puppeteer.js';
 
 // Re-exported so existing scripts (smoke-pdf, rerender-all-invoices) that
@@ -212,51 +213,6 @@ async function fetchInvoiceData(invoiceId: number): Promise<InvoiceData | null> 
   return data;
 }
 
-// ---- HTML wrapper ---------------------------------------------------
-
-// Print overrides for multi-page invoices. The template is one tall
-// `.sheet` div whose padding + min-height:11in only apply at the element
-// edges — so before this, page 2+ began flush against the top of the
-// paper and a short invoice was still forced to a full 11in. We let the
-// Puppeteer page margins (set in page.pdf) own the top/bottom whitespace
-// on EVERY page and neutralize the sheet's own vertical sizing. `.sheet`
-// is a hashed CSS-module class, so we target it structurally as the sole
-// body child. html/body get the cream background so the Puppeteer margin
-// bands are paper-colored too, not white. Rows don't split across a page
-// break; the table header repeats per page (Chromium default, explicit).
-const PRINT_OVERRIDES = `
-html, body { background: #fdfcf8; margin: 0; }
-body > div:first-child {
-  min-height: 0 !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
-table { page-break-inside: auto; }
-tr { page-break-inside: avoid; }
-thead { display: table-header-group; }
-`;
-
-function wrapHtml(ssrHtml: string, css: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<style>${css}</style>
-<style>${PRINT_OVERRIDES}</style>
-</head>
-<body>${ssrHtml}</body>
-</html>`;
-}
-
-// Small right-aligned "Page X / N" footer. Puppeteer header/footer
-// templates render in an isolated context with font-size 0 by default, so
-// size/padding are set inline. The horizontal padding matches the sheet's
-// 0.85in side inset; the bottom page margin reserves room for it.
-const FOOTER_TEMPLATE = `
-<div style="width:100%; font-size:8px; color:#5a6478; font-family: sans-serif; padding:0 0.85in; text-align:right;">
-  Page <span class="pageNumber"></span> / <span class="totalPages"></span>
-</div>`;
-
 // ---- public API -----------------------------------------------------
 
 export async function renderInvoicePdf(invoiceId: number): Promise<Buffer> {
@@ -271,7 +227,7 @@ export async function renderInvoicePdf(invoiceId: number): Promise<Buffer> {
   const css = await getCss();
   log('render-to-string');
   const ssrHtml = renderToString(createElement(Template, { data }));
-  const html = wrapHtml(ssrHtml, css);
+  const html = wrapPrintHtml(ssrHtml, css);
   log(`html=${html.length} bytes, acquiring page`);
   return withPage(async (page) => {
     log('setContent');
@@ -282,17 +238,7 @@ export async function renderInvoicePdf(invoiceId: number): Promise<Buffer> {
     log('await fonts.ready');
     await page.evaluate(() => document.fonts.ready);
     log('page.pdf');
-    const pdf = await page.pdf({
-      format: 'Letter',
-      printBackground: true,
-      // Top/bottom margins give every page (page 1 AND continuation
-      // pages) breathing room instead of starting flush at the edge.
-      // Left/right stay 0 — the sheet owns its 0.85in horizontal inset.
-      margin: { top: '0.55in', right: 0, bottom: '0.7in', left: 0 },
-      displayHeaderFooter: true,
-      headerTemplate: '<div></div>',
-      footerTemplate: FOOTER_TEMPLATE,
-    });
+    const pdf = await page.pdf(PAGINATED_PDF_OPTIONS);
     log(`pdf=${pdf.length} bytes`);
     return Buffer.from(pdf);
   });

--- a/server/lib/pdf.ts
+++ b/server/lib/pdf.ts
@@ -214,16 +214,48 @@ async function fetchInvoiceData(invoiceId: number): Promise<InvoiceData | null> 
 
 // ---- HTML wrapper ---------------------------------------------------
 
+// Print overrides for multi-page invoices. The template is one tall
+// `.sheet` div whose padding + min-height:11in only apply at the element
+// edges — so before this, page 2+ began flush against the top of the
+// paper and a short invoice was still forced to a full 11in. We let the
+// Puppeteer page margins (set in page.pdf) own the top/bottom whitespace
+// on EVERY page and neutralize the sheet's own vertical sizing. `.sheet`
+// is a hashed CSS-module class, so we target it structurally as the sole
+// body child. html/body get the cream background so the Puppeteer margin
+// bands are paper-colored too, not white. Rows don't split across a page
+// break; the table header repeats per page (Chromium default, explicit).
+const PRINT_OVERRIDES = `
+html, body { background: #fdfcf8; margin: 0; }
+body > div:first-child {
+  min-height: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+table { page-break-inside: auto; }
+tr { page-break-inside: avoid; }
+thead { display: table-header-group; }
+`;
+
 function wrapHtml(ssrHtml: string, css: string): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <style>${css}</style>
+<style>${PRINT_OVERRIDES}</style>
 </head>
 <body>${ssrHtml}</body>
 </html>`;
 }
+
+// Small right-aligned "Page X / N" footer. Puppeteer header/footer
+// templates render in an isolated context with font-size 0 by default, so
+// size/padding are set inline. The horizontal padding matches the sheet's
+// 0.85in side inset; the bottom page margin reserves room for it.
+const FOOTER_TEMPLATE = `
+<div style="width:100%; font-size:8px; color:#5a6478; font-family: sans-serif; padding:0 0.85in; text-align:right;">
+  Page <span class="pageNumber"></span> / <span class="totalPages"></span>
+</div>`;
 
 // ---- public API -----------------------------------------------------
 
@@ -253,7 +285,13 @@ export async function renderInvoicePdf(invoiceId: number): Promise<Buffer> {
     const pdf = await page.pdf({
       format: 'Letter',
       printBackground: true,
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
+      // Top/bottom margins give every page (page 1 AND continuation
+      // pages) breathing room instead of starting flush at the edge.
+      // Left/right stay 0 — the sheet owns its 0.85in horizontal inset.
+      margin: { top: '0.55in', right: 0, bottom: '0.7in', left: 0 },
+      displayHeaderFooter: true,
+      headerTemplate: '<div></div>',
+      footerTemplate: FOOTER_TEMPLATE,
     });
     log(`pdf=${pdf.length} bytes`);
     return Buffer.from(pdf);

--- a/server/lib/quote-pdf.ts
+++ b/server/lib/quote-pdf.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 import db from '../db/index.js';
 import { putObject, getObjectBytes } from './s3.js';
 import { withPage, closeBrowser } from './puppeteer.js';
+import { wrapPrintHtml, PAGINATED_PDF_OPTIONS } from './pdf-print.js';
 
 // Kept under the old name in case a caller imports it; the browser now
 // lives in lib/puppeteer.ts.
@@ -169,32 +170,17 @@ export async function fetchQuoteData(quoteId: number): Promise<QuoteData | null>
   };
 }
 
-function wrapHtml(ssrHtml: string, css: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<style>${css}</style>
-</head>
-<body>${ssrHtml}</body>
-</html>`;
-}
-
 export async function renderQuotePdf(quoteId: number): Promise<Buffer> {
   const data = await fetchQuoteData(quoteId);
   if (!data) throw new Error(`Quote ${quoteId} not found`);
   const Template = await getTemplate();
   const css = await getCss();
   const ssrHtml = renderToString(createElement(Template, { data }));
-  const html = wrapHtml(ssrHtml, css);
+  const html = wrapPrintHtml(ssrHtml, css);
   return withPage(async (page) => {
     await page.setContent(html, { waitUntil: 'load' });
     await page.evaluate(() => document.fonts.ready);
-    const pdf = await page.pdf({
-      format: 'Letter',
-      printBackground: true,
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
-    });
+    const pdf = await page.pdf(PAGINATED_PDF_OPTIONS);
     return Buffer.from(pdf);
   });
 }


### PR DESCRIPTION
> Stacked on #15 (both edit the PDF render path). Retarget to `main` once #15 merges.

## Why
Invoices **and quotes** that spill to a second page started their content flush against the top edge, and short docs were forced to a full 11in page. Root cause: each doc is one tall `.sheet` (padding + `min-height` on the element edges only), rendered with Puppeteer `margin: 0`.

## What — shared `server/lib/pdf-print.ts`, used by `lib/pdf.ts` (invoice) + `lib/quote-pdf.ts` (quote)
- **Page margins** top `0.55in` / bottom `0.7in` on every page; left/right `0` (the sheet owns its horizontal inset).
- **"Page X / N" footer** via `displayHeaderFooter` + `footerTemplate`. No repeated logo header.
- **Print-layout fixes** (injected, invoice/quote only — shared `sheet.module.css` untouched):
  - Force **block layout** for print — the sheet is `display:flex` on screen, and flex children can't fragment across printed pages in Chromium, so a long table jumped wholesale to page 2.
  - **Re-allow a page break after subless rows** — the templates set `break-after:avoid` on every parent row (to keep a line glued to its modification/delivery sub-rows); for a line with no subs that chained into "never break anywhere", making the whole table atomic. Rows with subs still stay with their children.
  - Paint `html/body` cream so the margin bands stay paper-colored.

## Testing
- 22-line quote → page 1 fills, flows to page 2 with footer (was: empty page 1).
- 20-line invoice → 2 pages; short invoice/quote → 1 page; single-page layout intact.
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
