### PR TITLE
Fix: free EC2 disk before pull (deploy hit 'no space left on device')

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,14 @@ jobs:
           # hostname the next line connects to.
           echo "${{ secrets.EC2_HOST }} ${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
+          # `docker system prune -af` FIRST: each deploy pulls fresh :latest
+          # images (the backend carries Chromium, ~hundreds of MB), and the
+          # superseded layers pile up until the host volume fills — which is
+          # exactly what broke the #19 deploy ("no space left on device" mid
+          # pull). Pruning unused images/containers before the pull frees that
+          # space and keeps the host bounded. Running containers hold the
+          # current images, so they're protected.
+          #
           # Order matters and the && chain is the safety rail:
           #   pull new images
           #   → back up prod + apply pending migrations + validate, all in one
@@ -67,6 +75,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} \
             "cd /home/ubuntu/airtight-container \
+              && docker system prune -af \
               && docker compose pull \
               && mkdir -p /home/ubuntu/airtight-backups \
               && docker compose run --rm --user root \


### PR DESCRIPTION
## What
`docker system prune -af` before `docker compose pull` in the deploy step.

## Why
The **#19 deploy failed** at `docker compose pull` on the EC2 host:
```
write /var/lib/docker/image/overlay2/.tmp-repositories.json: no space left on device
```
Images built + pushed fine; the migrate step never ran. Root cause is host disk: ~19 deploys of fresh `:latest` images (the backend bundles Chromium) left superseded layers piling up until the volume filled, and the new (slightly larger, now with `postgresql16-client`) image tipped it over.

## Fix
Reclaim unused images/containers/networks before pulling. Running containers hold the current images so they're protected; steady-state the host keeps ~1–2 image versions instead of 19. This also lets the deploy **self-heal** the full disk on the next run.

## Note
#14 (quote-promote) and #15 (puppeteer) are already on prod (their 2026-06-06 deploys are green). This unblocks **#19's** content (footer/Intake/migration) — when this merges, the deploy prunes → pulls → backs up + migrates 0024 + validates → up.

If the volume is so full that even prune can't free enough, free it manually first: `ssh <ec2> 'docker system prune -af'`, then re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)