### PR TITLE
fix(invoice): squash money/date/round-trip bugs across invoicing

### DIFF
--- a/client/src/components/forms/InvoiceEditor.tsx
+++ b/client/src/components/forms/InvoiceEditor.tsx
@@ -6,6 +6,7 @@ import type {
 } from '../templates/invoice/types';
 import { AddressFields, Button, CurrencyInput, IconButton } from '../ui';
 import { fmtCurrency } from '../templates/invoice/format';
+import { easternDateToISO, isoToEasternDate } from '../../lib/dates';
 import { ModificationRows } from './ModificationRows';
 import { DoorOrientationField } from './DoorOrientationField';
 import styles from './InvoiceEditor.module.css';
@@ -44,13 +45,6 @@ const TAX_PRESETS: Array<{ label: string; rate: string }> = [
 
 const isPreset = (rate: string | null) =>
   rate != null && TAX_PRESETS.some((p) => p.rate && p.rate === rate);
-
-const asISODate = (iso: string | null | undefined): string => {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (!Number.isFinite(d.getTime())) return '';
-  return d.toISOString().substring(0, 10);
-};
 
 export default function InvoiceEditor({
   initial,
@@ -167,11 +161,17 @@ export default function InvoiceEditor({
     for (const c of draft.containers) {
       subtotal += Number(c.sale_price ?? 0);
       subtotal += Number(c.trucking_rate ?? 0);
+      // Presence, not sign — a container with per-mod line items uses their
+      // sum even when it nets to zero/negative (discount lines). Mirrors
+      // recomputeTotals in server/lib/invoice-ops.ts.
+      const hasMods = c.modifications.some(
+        (m) => (m.description ?? '').trim() !== '',
+      );
       const perMod = c.modifications.reduce(
         (sum, m) => sum + Number(m.price ?? 0) * (m.quantity || 1),
         0,
       );
-      if (perMod > 0) subtotal += perMod;
+      if (hasMods) subtotal += perMod;
       else subtotal += Number(c.modification_price ?? 0);
     }
     const taxRate = Number(draft.tax_rate ?? 0);
@@ -328,11 +328,13 @@ export default function InvoiceEditor({
             <input
               type="date"
               className={styles.input}
-              value={asISODate(draft.invoice_date)}
+              value={isoToEasternDate(draft.invoice_date)}
               onChange={(e) =>
                 updateInvoice(
                   'invoice_date',
-                  e.target.value ? new Date(e.target.value).toISOString() : draft.invoice_date,
+                  e.target.value
+                    ? easternDateToISO(e.target.value) ?? draft.invoice_date
+                    : draft.invoice_date,
                 )
               }
             />

--- a/client/src/lib/dates.test.ts
+++ b/client/src/lib/dates.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { easternDateToISO, isoToEasternDate, todayEastern } from './dates';
+
+describe('isoToEasternDate', () => {
+  it('formats a UTC timestamp to the Eastern calendar day', () => {
+    // 2026-07-13 02:00 UTC = 2026-07-12 22:00 EDT
+    expect(isoToEasternDate('2026-07-13T02:00:00.000Z')).toBe('2026-07-12');
+  });
+
+  it('passes a bare YYYY-MM-DD through unchanged', () => {
+    expect(isoToEasternDate('2026-06-01')).toBe('2026-06-01');
+  });
+
+  it('returns empty string for nullish/invalid input', () => {
+    expect(isoToEasternDate(null)).toBe('');
+    expect(isoToEasternDate('')).toBe('');
+    expect(isoToEasternDate('not-a-date')).toBe('');
+  });
+});
+
+describe('easternDateToISO', () => {
+  it('maps a picked calendar day to noon UTC (same day everywhere in the US)', () => {
+    expect(easternDateToISO('2026-06-01')).toBe('2026-06-01T12:00:00.000Z');
+  });
+
+  it('round-trips back to the same Eastern day (no off-by-one)', () => {
+    const iso = easternDateToISO('2026-06-01');
+    expect(iso).not.toBeNull();
+    expect(isoToEasternDate(iso)).toBe('2026-06-01');
+  });
+
+  it('returns null for empty input', () => {
+    expect(easternDateToISO('')).toBeNull();
+    expect(easternDateToISO(null)).toBeNull();
+  });
+});
+
+describe('todayEastern', () => {
+  it('returns a YYYY-MM-DD string', () => {
+    expect(todayEastern()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/client/src/lib/dates.ts
+++ b/client/src/lib/dates.ts
@@ -1,0 +1,47 @@
+// Date helpers for invoice/quote dates. These fields are calendar days in
+// the yard's timezone (America/New_York), not instants. The server stores
+// invoice_date as a timestamptz; we canonicalize a picked calendar day to
+// noon UTC so it renders as the same day in every US timezone and stays
+// stable across save/reload round-trips (noon UTC is the same calendar day
+// from Hawaii through Eastern). Using bare `new Date("YYYY-MM-DD")` parses
+// as UTC midnight, which displays as the previous day for any ET viewer.
+
+const EASTERN = 'America/New_York';
+
+// timestamptz/ISO string -> "YYYY-MM-DD" for an <input type="date">,
+// resolved in Eastern time. A value already in "YYYY-MM-DD" form is
+// returned unchanged.
+export function isoToEasternDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '';
+  // en-CA renders as YYYY-MM-DD.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: EASTERN,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+// "YYYY-MM-DD" picked calendar day -> ISO timestamp at noon UTC (the same
+// calendar day in every US timezone, and stable when read back through
+// isoToEasternDate). A non-date string is best-effort parsed; empty input
+// yields null.
+export function easternDateToISO(
+  dateStr: string | null | undefined,
+): string | null {
+  if (!dateStr) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!m) {
+    const d = new Date(dateStr);
+    return Number.isFinite(d.getTime()) ? d.toISOString() : null;
+  }
+  return `${m[1]}-${m[2]}-${m[3]}T12:00:00.000Z`;
+}
+
+// Today's calendar day in Eastern time as "YYYY-MM-DD".
+export function todayEastern(): string {
+  return isoToEasternDate(new Date().toISOString());
+}

--- a/client/src/routes/CreateInvoice.tsx
+++ b/client/src/routes/CreateInvoice.tsx
@@ -13,6 +13,7 @@ import { AddClientModal } from '../components/forms/AddClientModal';
 import { DoorOrientationField } from '../components/forms/DoorOrientationField';
 import { useDirtyForm } from '../lib/useDirtyForm';
 import { useDraftPersistence } from '../lib/useDraftPersistence';
+import { easternDateToISO, todayEastern } from '../lib/dates';
 import InvoiceTemplate from '../components/templates/invoice/InvoiceTemplate';
 import { fmtCurrency, fmtDate } from '../components/templates/invoice/format';
 import type {
@@ -125,7 +126,9 @@ const customerCityState = (c: ClientRow | null): string => {
   return c.street ?? '';
 };
 
-const todayISO = (): string => new Date().toISOString().substring(0, 10);
+// Default the invoice date to today's calendar day in Eastern time — a
+// naive UTC substring rolls to tomorrow for late-evening ET creation.
+const todayISO = todayEastern;
 
 // User-facing percent ↔ stored decimal rate. We display "3.5" but
 // persist 0.035, and similarly for tax rates so server math stays
@@ -449,9 +452,7 @@ export default function CreateInvoice() {
       invoice_number: 'PLACEHOLDER',
       invoice_taxed: invoiceTaxed,
       invoice_credit: invoiceCredit,
-      invoice_date: invoiceDate
-        ? new Date(invoiceDate).toISOString()
-        : new Date().toISOString(),
+      invoice_date: easternDateToISO(invoiceDate) ?? new Date().toISOString(),
       sent_at: null,
       pdf_s3_key: null,
       deleted_at: null,
@@ -592,6 +593,7 @@ export default function CreateInvoice() {
           client_id: selectedClient.id,
           invoice_taxed: invoiceTaxed,
           invoice_credit: invoiceCredit,
+          invoice_date: easternDateToISO(invoiceDate),
           tax_rate: taxRate,
           cc_fee_rate: ccFeeRate,
           ship_to_same_as_billing: shipSameAsBilling,

--- a/client/src/routes/InvoiceDetail.tsx
+++ b/client/src/routes/InvoiceDetail.tsx
@@ -272,6 +272,7 @@ export default function InvoiceDetail() {
             modifications: c.modifications.map((m, i) => ({
               description: m.description,
               price: m.price,
+              quantity: m.quantity ?? 1,
               position: i,
             })),
           })),

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -4,7 +4,21 @@
 
 ---
 
-## TL;DR — 2026-06-19 security + logging sweep on 4 local branches (NOT pushed / merged / deployed)
+## TL;DR — 2026-07-14 invoicing bug sweep (PR: `fix/invoice-edit-drops-mod-quantity`, pushed)
+
+Triggered by a bookkeeper report: editing invoice **202607003**'s date changed its total ($6600.09 → $2860.09). Root cause — the invoice-edit save dropped per-mod `quantity`, so the server reset every line to qty 1 and recomputed the total down. Confirmed against prod (total = exact sum of its 78 line items at qty 1). A sonnet-agent sweep of the whole invoicing path found more; all fixed on the branch + committed (`ee7d338`) and opened as a PR:
+
+- **Money:** quote→invoice promote now carries the quote's tax + CC-fee (was making every promoted invoice untaxed → undercharge); discount/zero-net modification lines no longer dropped from the subtotal (presence-check, not `> 0`).
+- **Dates:** CreateInvoice sends `invoice_date`; invoice dates read/written in Eastern time (UTC-midnight off-by-one fixed); `monthPrefix` uses the Eastern month like quote numbering.
+- **Integrity/hardening:** blank ship-to/delivery normalized to null (delivery-sheet address cascade fix); `tax_rate`/`cc_fee_rate` use COALESCE; Zod validation on POST/PUT `/api/v2/invoice` (mod quantity ≥ 1).
+
+Tests green: **236 server / 57 client**, client build clean (+10 server, +7 client new tests). **Deferred (owner decision):** exclude cancelled invoices from P&L/dashboard revenue (`AND status <> 'cancelled'`), and a float→integer-cents tax-rounding refactor.
+
+**Two landmines surfaced:** (1) the prod DB is **`containers_prod`**, not `containers` (a stale `containers` copy also exists on the host); (2) the security-sweep pino logging does **not** capture request bodies or field diffs on *successful* writes, so this data-corruption bug left no forensic trail — worth logging write diffs on invoice/quote mutations.
+
+---
+
+## Also in flight — 2026-06-19 security + logging sweep on 4 local branches (NOT pushed / merged / deployed)
 
 **Work in flight (local commits only, nothing pushed):** a 4-phase adversarial-review-driven security + logging sweep. Each phase is a committed feature branch, **stacked in order off `main`** (each branches off the previous because later phases use the PR1 logger):
 - `feat/logging-foundation` — pino + pino-http structured logging (auth/cookie/token redaction, per-request `x-request-id` correlation), centralized `errorBoundary`, error-message hygiene sweep (25 `err.message` 5xx leaks genericized; Twilio passthrough kept), SMS-response token stripped, Docker json-file log rotation.

--- a/server/lib/invoice-ops.ts
+++ b/server/lib/invoice-ops.ts
@@ -7,11 +7,22 @@
 // + BEGIN/COMMIT/ROLLBACK around these.
 
 import type { PoolClient } from 'pg';
+import { easternMonthPrefix } from './quote-number.js';
 
 // Stable advisory-lock key for sales-invoice number sequencing. Hex
 // derived from "AIRSEQ#" ASCII so the value is namespaced. Postgres
 // pg_advisory_xact_lock takes bigint; we pass as a decimal string.
 const SALES_INVOICE_SEQ_LOCK_KEY = 0x4149_5253_4551_4e23n.toString();
+
+// Collapse blank/whitespace-only text to null so the `??`/COALESCE
+// fallbacks downstream (notably the delivery-sheet address cascade in
+// report-resolvers/delivery.ts) treat a cleared field as unset rather
+// than as a present empty string that short-circuits the cascade.
+function blankToNull(v: string | null | undefined): string | null {
+  if (v == null) return null;
+  const s = String(v).trim();
+  return s === '' ? null : s;
+}
 
 export interface IncomingModification {
   description?: string;
@@ -96,9 +107,10 @@ export async function getNextInvoiceNumber(
 }
 
 export function monthPrefix(date: Date = new Date()): number {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  return parseInt(`${y}${m}`, 10);
+  // Eastern-time YYYYMM so an invoice created late-evening ET on the last
+  // day of a month keeps that month's sequence instead of rolling into the
+  // next with the container's UTC clock. Mirrors quote numbering.
+  return parseInt(easternMonthPrefix(date), 10);
 }
 
 /**
@@ -147,7 +159,11 @@ export async function recomputeTotals(
     subtotal += Number(r.sale_price ?? 0);
     subtotal += Number(r.trucking_rate ?? 0);
     const perMod = r.sold_id != null ? modsBySold.get(r.sold_id) : undefined;
-    if (perMod !== undefined && perMod > 0) {
+    if (perMod !== undefined) {
+      // Presence, not sign: a container that has per-mod line items uses
+      // their sum even when it nets to zero or negative (discount/credit
+      // lines). Only fall back to the legacy scalar when there are no
+      // per-mod rows at all — otherwise a discount silently vanishes.
       subtotal += perMod;
     } else {
       subtotal += Number(r.modification_price ?? 0);
@@ -203,8 +219,8 @@ export async function updateInvoiceFull(
          invoice_taxed = COALESCE($2, invoice_taxed),
          invoice_credit = COALESCE($3, invoice_credit),
          invoice_date = COALESCE($4, invoice_date),
-         tax_rate = $5,
-         cc_fee_rate = $6,
+         tax_rate = COALESCE($5, tax_rate),
+         cc_fee_rate = COALESCE($6, cc_fee_rate),
          ship_to_same_as_billing = COALESCE($7, ship_to_same_as_billing),
          ship_to_name = $8,
          ship_to_street = $9,
@@ -220,11 +236,11 @@ export async function updateInvoiceFull(
       body.tax_rate ?? null,
       body.cc_fee_rate ?? null,
       body.ship_to_same_as_billing ?? null,
-      body.ship_to_name ?? null,
-      body.ship_to_street ?? null,
-      body.ship_to_city ?? null,
-      body.ship_to_state ?? null,
-      body.ship_to_zip ?? null,
+      blankToNull(body.ship_to_name),
+      blankToNull(body.ship_to_street),
+      blankToNull(body.ship_to_city),
+      blankToNull(body.ship_to_state),
+      blankToNull(body.ship_to_zip),
       invoiceId,
     ],
   );
@@ -337,11 +353,11 @@ export async function updateInvoiceFull(
         ct.invoice_notes ?? null,
         ct.outbound_trucking_company_id ?? null,
         ct.door_orientation ?? null,
-        ct.delivery_name ?? null,
-        ct.delivery_street ?? null,
-        ct.delivery_city ?? null,
-        ct.delivery_state ?? null,
-        ct.delivery_zip ?? null,
+        blankToNull(ct.delivery_name),
+        blankToNull(ct.delivery_street),
+        blankToNull(ct.delivery_city),
+        blankToNull(ct.delivery_state),
+        blankToNull(ct.delivery_zip),
       ],
     );
 

--- a/server/lib/quote-ops.ts
+++ b/server/lib/quote-ops.ts
@@ -294,6 +294,10 @@ export interface PromoteQuoteBody {
 interface QuotePromoteRow {
   client_id: number;
   deleted_at: Date | string | null;
+  quote_taxed: boolean;
+  quote_credit: boolean;
+  tax_rate: string | null;
+  cc_fee_rate: string | null;
 }
 
 interface QuoteLineForPromote {
@@ -326,7 +330,8 @@ export async function promoteQuoteToInvoice(
   body: PromoteQuoteBody,
 ): Promise<{ id: number; invoice_number: number }> {
   const { rows: qRows } = await client.query<QuotePromoteRow>(
-    'SELECT client_id, deleted_at FROM quotes WHERE id = $1',
+    `SELECT client_id, deleted_at, quote_taxed, quote_credit, tax_rate, cc_fee_rate
+       FROM quotes WHERE id = $1`,
     [quoteId],
   );
   const quote = qRows[0];
@@ -421,15 +426,22 @@ export async function promoteQuoteToInvoice(
     };
   });
 
+  // Carry the quote's tax + credit-card-fee settings onto the invoice.
+  // Without this every promoted invoice came out untaxed with a null
+  // rate, silently dropping the tax/CC fee the customer was quoted.
   const created = await createInvoice(client, {
     client_id: quote.client_id,
-    invoice_taxed: false,
-    invoice_credit: false,
+    invoice_taxed: quote.quote_taxed,
+    invoice_credit: quote.quote_credit,
     containers: invoiceContainers.map((c) => ({ inventory_id: c.inventory_id })),
   });
 
   await updateInvoiceFull(client, created.id, {
     client_id: quote.client_id,
+    invoice_taxed: quote.quote_taxed,
+    invoice_credit: quote.quote_credit,
+    tax_rate: quote.tax_rate,
+    cc_fee_rate: quote.cc_fee_rate,
     ship_to_same_as_billing: body.ship_to_same_as_billing,
     ship_to_name: body.ship_to_name,
     ship_to_street: body.ship_to_street,

--- a/server/routes/v2/invoice.js
+++ b/server/routes/v2/invoice.js
@@ -10,6 +10,11 @@ import {
 	updateInvoiceFull,
 	deleteInvoiceCascade,
 } from "../../lib/invoice-ops.js";
+import { validateBody } from "../../middleware/validate.js";
+import {
+	createInvoiceSchema,
+	updateInvoiceSchema,
+} from "../../validation/invoice.js";
 
 const router = express.Router();
 
@@ -207,7 +212,7 @@ router.get("/:id", checkEmployee, async (req, res) => {
 
 // PR 3.5 + 3.10: number generation + container insertion live in
 // lib/invoice-ops.ts so tests can exercise them outside the HTTP stack.
-router.post("/", checkEmployee, async (req, res) => {
+router.post("/", checkEmployee, validateBody(createInvoiceSchema), async (req, res) => {
 	const clientId = req.body.client_id ?? req.body.contact_id;
 	if (!clientId) {
 		return res.status(400).json({ message: "client_id is required" });
@@ -244,7 +249,7 @@ const getDeletedAt = async (invoiceId) => {
 	return rows[0].deleted_at;
 };
 
-router.put("/:id", checkAdmin, async (req, res) => {
+router.put("/:id", checkAdmin, validateBody(updateInvoiceSchema), async (req, res) => {
 	const invoiceId = parseInt(req.params.id, 10);
 	if (!Number.isFinite(invoiceId)) {
 		return res.status(400).json({ message: "Invalid invoice id" });

--- a/server/tests/lib/invoice-totals.test.ts
+++ b/server/tests/lib/invoice-totals.test.ts
@@ -1,0 +1,176 @@
+// DB-free unit tests for the money/date logic in lib/invoice-ops.ts.
+// A fake PoolClient answers the SELECTs by SQL substring and records the
+// writes, so we assert the computed subtotal / normalized params without
+// a real Postgres (unlike invoice-ops.test.ts, which is integration).
+
+import { describe, expect, it, vi } from 'vitest';
+import type { PoolClient } from 'pg';
+import {
+  monthPrefix,
+  recomputeTotals,
+  updateInvoiceFull,
+} from '../../lib/invoice-ops.js';
+
+type Row = Record<string, unknown>;
+interface Call {
+  sql: string;
+  params: unknown[];
+}
+
+function recomputeClient(opts: {
+  ctRows: Row[];
+  modRows: Row[];
+  invoice: Row;
+}) {
+  const calls: Call[] = [];
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    calls.push({ sql, params });
+    if (sql.includes('AS sold_id') && sql.includes('invoice_containers'))
+      return { rows: opts.ctRows };
+    if (sql.includes('FROM sold_modifications')) return { rows: opts.modRows };
+    if (sql.startsWith('SELECT invoice_taxed')) return { rows: [opts.invoice] };
+    return { rows: [] };
+  });
+  return { client: { query } as unknown as PoolClient, calls };
+}
+
+function subtotalOf(calls: Call[]): unknown {
+  const upd = calls.find(
+    (c) => c.sql.includes('UPDATE invoices') && c.sql.includes('SET subtotal'),
+  );
+  return upd?.params[0];
+}
+
+describe('recomputeTotals — modification subtotal', () => {
+  const invoice = {
+    invoice_taxed: false,
+    invoice_credit: false,
+    tax_rate: null,
+    cc_fee_rate: null,
+  };
+
+  it('includes a negative-net (discount) modification instead of dropping it', async () => {
+    const { client, calls } = recomputeClient({
+      ctRows: [
+        { sold_id: 1, sale_price: '1000', trucking_rate: null, modification_price: '0' },
+      ],
+      modRows: [{ sold_id: 1, price: '-300', quantity: 1 }],
+      invoice,
+    });
+    await recomputeTotals(client, 1);
+    expect(subtotalOf(calls)).toBe('700.00');
+  });
+
+  it('uses a zero-net modification sum, not the stale legacy scalar', async () => {
+    const { client, calls } = recomputeClient({
+      ctRows: [
+        { sold_id: 1, sale_price: '1000', trucking_rate: null, modification_price: '999' },
+      ],
+      modRows: [{ sold_id: 1, price: '0', quantity: 1 }],
+      invoice,
+    });
+    await recomputeTotals(client, 1);
+    expect(subtotalOf(calls)).toBe('1000.00');
+  });
+
+  it('falls back to the legacy scalar only when there are no per-mod rows', async () => {
+    const { client, calls } = recomputeClient({
+      ctRows: [
+        { sold_id: 1, sale_price: '1000', trucking_rate: null, modification_price: '250' },
+      ],
+      modRows: [],
+      invoice,
+    });
+    await recomputeTotals(client, 1);
+    expect(subtotalOf(calls)).toBe('1250.00');
+  });
+
+  it('multiplies modification price by quantity', async () => {
+    const { client, calls } = recomputeClient({
+      ctRows: [
+        { sold_id: 1, sale_price: '0', trucking_rate: null, modification_price: null },
+      ],
+      modRows: [{ sold_id: 1, price: '150', quantity: 3 }],
+      invoice,
+    });
+    await recomputeTotals(client, 1);
+    expect(subtotalOf(calls)).toBe('450.00');
+  });
+});
+
+describe('monthPrefix — Eastern month boundary', () => {
+  it('keeps the prior month for a late-evening EDT instant that is next-day UTC', () => {
+    // 2026-08-01 02:00 UTC = 2026-07-31 22:00 EDT
+    expect(monthPrefix(new Date('2026-08-01T02:00:00Z'))).toBe(202607);
+  });
+
+  it('keeps the prior month across the EST (winter) boundary', () => {
+    // 2026-01-01 04:30 UTC = 2025-12-31 23:30 EST
+    expect(monthPrefix(new Date('2026-01-01T04:30:00Z'))).toBe(202512);
+  });
+
+  it('returns the Eastern month for a normal midday instant', () => {
+    expect(monthPrefix(new Date('2026-07-15T16:00:00Z'))).toBe(202607);
+  });
+});
+
+function updateClient() {
+  const calls: Call[] = [];
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    calls.push({ sql, params });
+    if (sql.includes('FROM invoices i') && sql.includes('JOIN clients'))
+      return {
+        rows: [
+          {
+            ship_to_same_as_billing: false,
+            ship_to_city: null,
+            ship_to_state: null,
+            client_city: null,
+            client_state: null,
+          },
+        ],
+      };
+    if (sql.includes('container_id FROM invoice_containers')) return { rows: [] };
+    if (sql.includes('FROM sold WHERE inventory_id')) return { rows: [{ id: 100 }] };
+    if (sql.startsWith('SELECT invoice_taxed'))
+      return {
+        rows: [
+          {
+            invoice_taxed: false,
+            invoice_credit: false,
+            tax_rate: null,
+            cc_fee_rate: null,
+          },
+        ],
+      };
+    if (sql.includes('AS sold_id') && sql.includes('invoice_containers'))
+      return { rows: [] };
+    if (sql.includes('FROM sold_modifications')) return { rows: [] };
+    return { rows: [] };
+  });
+  return { client: { query } as unknown as PoolClient, calls };
+}
+
+describe('updateInvoiceFull — blank address normalization', () => {
+  it('persists cleared ship-to / delivery fields as null, not empty string', async () => {
+    const { client, calls } = updateClient();
+    await updateInvoiceFull(client, 1, {
+      client_id: 5,
+      ship_to_name: '',
+      ship_to_street: '   ',
+      containers: [{ inventory_id: 11, delivery_name: '  ', delivery_street: '' }],
+    });
+    const invUpd = calls.find(
+      (c) => c.sql.includes('UPDATE invoices') && c.sql.includes('SET client_id'),
+    );
+    // [0]=client_id [1]=taxed [2]=credit [3]=date [4]=tax [5]=cc [6]=same
+    // [7]=name [8]=street [9]=city [10]=state [11]=zip [12]=id
+    expect(invUpd?.params[7]).toBeNull();
+    expect(invUpd?.params[8]).toBeNull();
+    const soldIns = calls.find((c) => c.sql.includes('INSERT INTO sold '));
+    // [0]=inv_id [1]=sale [2]=truck [3]=modprice [4]=dest [5]=notes
+    // [6]=truckco [7]=door [8]=del_name [9]=del_street ...
+    expect(soldIns?.params[8]).toBeNull();
+    expect(soldIns?.params[9]).toBeNull();
+  });
+});

--- a/server/tests/lib/quote-promote.test.ts
+++ b/server/tests/lib/quote-promote.test.ts
@@ -23,12 +23,27 @@ interface ModRow {
 // Builds a fake client. Records every (sql, params) and answers the
 // reads that promoteQuoteToInvoice + the invoice-ops it calls issue.
 function fakeClient(opts: {
-  quote?: { client_id: number; deleted_at: Date | string | null };
+  quote?: {
+    client_id: number;
+    deleted_at: Date | string | null;
+    quote_taxed?: boolean;
+    quote_credit?: boolean;
+    tax_rate?: string | null;
+    cc_fee_rate?: string | null;
+  };
   lines: LineRow[];
   mods?: ModRow[];
 }) {
   const calls: Array<{ sql: string; params: unknown[] }> = [];
-  const quote = opts.quote ?? { client_id: 42, deleted_at: null };
+  const quote = {
+    client_id: 42,
+    deleted_at: null,
+    quote_taxed: false,
+    quote_credit: false,
+    tax_rate: null,
+    cc_fee_rate: null,
+    ...opts.quote,
+  };
   const mods = opts.mods ?? [];
 
   const query = vi.fn(async (sql: string, params: unknown[] = []) => {
@@ -87,7 +102,54 @@ function soldInsertFor(
     }))[0];
 }
 
+// The createInvoice INSERT carries [invoice_number, client_id,
+// invoice_taxed, invoice_credit]; updateInvoiceFull's SET client_id
+// UPDATE carries [client_id, invoice_taxed, invoice_credit, invoice_date,
+// tax_rate, cc_fee_rate, ...].
+function invoiceInsert(calls: Array<{ sql: string; params: unknown[] }>) {
+  return calls.find((c) => c.sql.includes('INTO invoices'));
+}
+function invoiceUpdate(calls: Array<{ sql: string; params: unknown[] }>) {
+  return calls.find(
+    (c) => c.sql.includes('UPDATE invoices') && c.sql.includes('SET client_id'),
+  );
+}
+
 describe('promoteQuoteToInvoice', () => {
+  it('carries the quote tax + credit-card-fee settings onto the promoted invoice', async () => {
+    const { client, calls } = fakeClient({
+      quote: {
+        client_id: 42,
+        deleted_at: null,
+        quote_taxed: true,
+        quote_credit: true,
+        tax_rate: '0.06625',
+        cc_fee_rate: '0.03',
+      },
+      lines: [{ id: 1, sale_price: '1000', trucking_rate: null, destination: null }],
+    });
+    await promoteQuoteToInvoice(client, 5, { containers: [{ inventory_id: 11 }] });
+
+    const ins = invoiceInsert(calls);
+    expect(ins?.params[2]).toBe(true); // invoice_taxed
+    expect(ins?.params[3]).toBe(true); // invoice_credit
+
+    const upd = invoiceUpdate(calls);
+    expect(upd?.params[1]).toBe(true); // invoice_taxed
+    expect(upd?.params[2]).toBe(true); // invoice_credit
+    expect(upd?.params[4]).toBe('0.06625'); // tax_rate
+    expect(upd?.params[5]).toBe('0.03'); // cc_fee_rate
+  });
+
+  it('leaves the promoted invoice untaxed when the quote is untaxed', async () => {
+    const { client, calls } = fakeClient({
+      lines: [{ id: 1, sale_price: '1000', trucking_rate: null, destination: null }],
+    });
+    await promoteQuoteToInvoice(client, 5, { containers: [{ inventory_id: 11 }] });
+    expect(invoiceInsert(calls)?.params[2]).toBe(false);
+    expect(invoiceUpdate(calls)?.params[4]).toBeNull();
+  });
+
   it('maps quote lines onto containers positionally', async () => {
     const { client, calls } = fakeClient({
       lines: [

--- a/server/validation/invoice.ts
+++ b/server/validation/invoice.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+// Validation for the sales-invoice create/update endpoints. Mirrors the
+// server's own IncomingContainer / UpdateInvoiceBody / CreateInvoiceBody
+// contracts (lib/invoice-ops.ts) field-for-field: validateBody strips
+// unknown keys, so anything the write path reads must be listed here or
+// it would be silently dropped. Money fields accept the raw strings the
+// FE sends (pg numeric stores them losslessly) and permit negatives
+// (discount / credit lines). Modification quantity must be a whole number
+// >= 1 — the one place we tighten, since a 0/negative qty would corrupt
+// the recomputed total.
+
+const moneyish = z.union([z.string(), z.number()]).nullable().optional();
+const nullableShortText = z.string().trim().max(255).nullable().optional();
+
+const invoiceModSchema = z.object({
+  description: z.string().trim().max(500).optional(),
+  price: moneyish,
+  quantity: z.coerce.number().int().min(1).optional(),
+  position: z.coerce.number().int().nullable().optional(),
+});
+
+const invoiceContainerSchema = z.object({
+  inventory_id: z.coerce.number().int().positive(),
+  sale_price: moneyish,
+  trucking_rate: moneyish,
+  modification_price: moneyish,
+  invoice_notes: z.string().trim().max(5000).nullable().optional(),
+  outbound_trucking_company_id: z.coerce
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional(),
+  door_orientation: nullableShortText,
+  delivery_name: nullableShortText,
+  delivery_street: nullableShortText,
+  delivery_city: nullableShortText,
+  delivery_state: nullableShortText,
+  delivery_zip: nullableShortText,
+  modifications: z.array(invoiceModSchema).max(200).optional(),
+});
+
+export const createInvoiceSchema = z.object({
+  // The route accepts either key and coalesces client_id ?? contact_id.
+  client_id: z.coerce.number().int().positive().optional(),
+  contact_id: z.coerce.number().int().positive().optional(),
+  invoice_taxed: z.boolean().optional(),
+  invoice_credit: z.boolean().optional(),
+  containers: z
+    .array(
+      z.object({
+        id: z.coerce.number().int().positive().optional(),
+        inventory_id: z.coerce.number().int().positive().optional(),
+      }),
+    )
+    .max(200)
+    .optional(),
+});
+
+export const updateInvoiceSchema = z.object({
+  client_id: z.coerce.number().int().positive().optional(),
+  invoice_taxed: z.boolean().optional(),
+  invoice_credit: z.boolean().optional(),
+  // A timestamptz/ISO string; kept lenient so a value echoed back from the
+  // GET (pg timestamp text) isn't rejected. pg parses it on write.
+  invoice_date: z.string().max(64).nullable().optional(),
+  tax_rate: moneyish,
+  cc_fee_rate: moneyish,
+  ship_to_same_as_billing: z.boolean().optional(),
+  ship_to_name: nullableShortText,
+  ship_to_street: nullableShortText,
+  ship_to_city: nullableShortText,
+  ship_to_state: nullableShortText,
+  ship_to_zip: nullableShortText,
+  containers: z.array(invoiceContainerSchema).max(200).optional(),
+});
+
+export type CreateInvoiceInput = z.infer<typeof createInvoiceSchema>;
+export type UpdateInvoiceInput = z.infer<typeof updateInvoiceSchema>;


### PR DESCRIPTION
## Why

Bookkeeper reported that editing invoice **202607003**'s date changed its total ($6600.09 → $2860.09). Root cause: the invoice-edit save (`InvoiceDetail.tsx`) dropped per-modification `quantity`, and the server delete-and-reinserts all mods on save (`updateInvoiceFull`), defaulting the missing quantity to 1 and recomputing the total down. **Any** edit-and-save through that screen flattened every multi-quantity line — the date was a red herring. Confirmed against prod (`containers_prod`): the current total is the exact sum of its 78 line items at qty 1.

A sonnet-agent sweep of the rest of the invoicing path turned up several more real bugs, fixed here in one pass.

## What changed

**Money correctness**
- **Quote → invoice promote now carries the quote's tax + CC-fee settings.** It was hardcoding `invoice_taxed/credit = false` and null rates, so every promoted taxed quote became an untaxed invoice (silent undercharge). `quote-ops.ts`
- **Discount / zero-net modifications no longer dropped from the subtotal.** `recomputeTotals` (and the editor preview) used a `perMod > 0` guard that fell back to the legacy scalar for any container whose mods net ≤ 0, deleting the discount. Now a presence check, mirroring the quote path. `invoice-ops.ts`, `InvoiceEditor.tsx`
- **Edit save no longer resets modification quantity to 1** (the reported bug). `InvoiceDetail.tsx`

**Dates (all Eastern time now)**
- `CreateInvoice` actually sends `invoice_date` (the picker was previously discarded, so backdated invoices silently got `now()`).
- Invoice dates are read/written in Eastern time via a shared helper, fixing a UTC-midnight off-by-one that shifted a picked day back one.
- `monthPrefix` uses the Eastern month like quote numbering, so a late-evening-ET invoice keeps that month's sequence. `dates.ts`, `InvoiceEditor.tsx`, `CreateInvoice.tsx`, `invoice-ops.ts`

**Integrity / hardening**
- Blank ship-to / delivery fields normalize to `null` so the driver delivery-sheet address cascade doesn't short-circuit on an empty string. `invoice-ops.ts`
- `tax_rate` / `cc_fee_rate` use `COALESCE` in `updateInvoiceFull` (no accidental null-out).
- Zod validation on `POST` / `PUT /api/v2/invoice` (modification quantity ≥ 1), mirroring the existing quote validation. The schema mirrors the server's `IncomingContainer` / `UpdateInvoiceBody` contracts field-for-field so `validateBody`'s unknown-key stripping can't drop a field the write path reads. `validation/invoice.ts`, `routes/v2/invoice.js`

## Deliberately deferred (need your call)
- **Cancelled invoices still count as revenue** in P&L/dashboard (`AND status <> 'cancelled'` missing) — left out pending confirmation of intended semantics.
- **Float `toFixed(2)` tax rounding** occasionally off by 1¢ at half-cent boundaries — the clean fix is an integer-cents refactor across invoices + quotes, not a one-liner.

## Testing
- **Server:** `tsc --noEmit` clean · **236 tests pass** (+8 `invoice-totals`: negative/zero-net mods, Eastern month boundary, blank-address normalization; +2 promote tax-carry).
- **Client:** `tsc` clean · **57 tests pass** (+7 date-helper round-trip) · **production build clean**.
- New tests lock the two headline money bugs: a −$300 discount now yields subtotal $700 (was $1000), and a taxed quote promotes to a taxed invoice.

## Notes / landmines found
- Prod DB is **`containers_prod`**, not `containers` (a stale `containers` copy also lives on the host).
- The security-sweep pino logging does **not** capture request bodies/field diffs on *successful* writes — this corruption left no forensic trail. Worth logging write diffs on invoice/quote mutations.
- Recovery for 202607003: the correct pre-edit invoice is preserved in S3 as `invoices/386.pdf` ($6600.09, rendered 2026-07-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTs1M76GqbKpvoefpz96ig
